### PR TITLE
Pin to Scala 2.12.x

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,3 @@
+updates.pin = [
+  { groupId = "org.scala-lang", artifactId = "scala-library", version = "2.12." }
+]


### PR DESCRIPTION
I think this should prevent PRs like https://github.com/typelevel/sbt-typelevel/pull/27.