### PR TITLE
Pin Scala.js to 1.7.x

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,3 +1,4 @@
 updates.pin = [
-  { groupId = "org.scala-lang", artifactId = "scala-library", version = "2.12." }
+  { groupId = "org.scala-lang", artifactId = "scala-library", version = "2.12." },
+  { groupId = "org.scala-js", artifactId = "sbt-scalajs", version = "1.7." }
 ]


### PR DESCRIPTION
Currently http4s-dom and outwatch are stuck on SJS 1.7 due to problems in https://github.com/scalameta/mdoc/pull/597.