### PR TITLE
Improve CI release config

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,8 +7,7 @@ ThisBuild / organizationName := "Typelevel"
 ThisBuild / scalaVersion := "2.12.15"
 
 enablePlugins(TypelevelCiReleasePlugin)
-ThisBuild / tlCiReleaseSnapshots := true
-ThisBuild / tlCiReleaseBranches := Seq("main")
+ThisBuild / tlCiReleaseSnapshotBranches := Seq("main")
 
 ThisBuild / developers := List(
   tlGitHubDev("armanbilge", "Arman Bilge"),

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,6 @@ ThisBuild / organizationName := "Typelevel"
 ThisBuild / scalaVersion := "2.12.15"
 
 enablePlugins(TypelevelCiReleasePlugin)
-ThisBuild / tlCiReleaseBranches := Seq("main")
 
 ThisBuild / developers := List(
   tlGitHubDev("armanbilge", "Arman Bilge"),

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ ThisBuild / organizationName := "Typelevel"
 ThisBuild / scalaVersion := "2.12.15"
 
 enablePlugins(TypelevelCiReleasePlugin)
-ThisBuild / tlCiReleaseSnapshotBranches := Seq("main")
+ThisBuild / tlCiReleaseBranches := Seq("main")
 
 ThisBuild / developers := List(
   tlGitHubDev("armanbilge", "Arman Bilge"),

--- a/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
+++ b/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
@@ -42,6 +42,7 @@ object TypelevelPlugin extends AutoPlugin {
   import autoImport._
   import TypelevelKernelPlugin.autoImport._
   import TypelevelSettingsPlugin.autoImport._
+  import TypelevelSonatypeCiReleasePlugin.autoImport._
   import GenerativePlugin.autoImport._
   import GitHubActionsPlugin.autoImport._
 
@@ -54,6 +55,7 @@ object TypelevelPlugin extends AutoPlugin {
     organizationName := "Typelevel",
     startYear := Some(java.time.YearMonth.now().getYear()),
     licenses += "Apache-2.0" -> url("http://www.apache.org/licenses/"),
+    tlCiReleaseBranches := Seq("main"),
     Def.derive(tlFatalWarnings := (tlFatalWarningsInCi.value && githubIsWorkflowBuild.value)),
     githubWorkflowBuildMatrixExclusions ++= {
       for {

--- a/sonatype-ci-release/src/main/scala/org/typelevel/sbt/TypelevelSonatypeCiReleasePlugin.scala
+++ b/sonatype-ci-release/src/main/scala/org/typelevel/sbt/TypelevelSonatypeCiReleasePlugin.scala
@@ -26,8 +26,8 @@ object TypelevelSonatypeCiReleasePlugin extends AutoPlugin {
   object autoImport {
     lazy val tlCiReleaseTags = settingKey[Boolean](
       "Controls whether or not v-prefixed tags should be released from CI (default true)")
-    lazy val tlCiReleaseSnapshotBranches = settingKey[Seq[String]](
-      "The branches in your repository to release snapshots from in CI (default: [])")
+    lazy val tlCiReleaseBranches = settingKey[Seq[String]](
+      "The branches in your repository to release from in CI on every push. Depending on your versioning scheme, they will be either snapshots or (hash) releases. Leave this empty if you only want CI releases for tags. (default: [])")
   }
 
   import autoImport._
@@ -38,7 +38,7 @@ object TypelevelSonatypeCiReleasePlugin extends AutoPlugin {
   override def trigger = noTrigger
 
   override def globalSettings =
-    Seq(tlCiReleaseTags := true, tlCiReleaseSnapshotBranches := Seq())
+    Seq(tlCiReleaseTags := true, tlCiReleaseBranches := Seq())
 
   override def buildSettings = Seq(
     githubWorkflowEnv ++= Map(
@@ -47,7 +47,7 @@ object TypelevelSonatypeCiReleasePlugin extends AutoPlugin {
     ),
     githubWorkflowPublishTargetBranches := {
       val snapshots =
-        tlCiReleaseSnapshotBranches.value.map(b => RefPredicate.Equals(Ref.Branch(b)))
+        tlCiReleaseBranches.value.map(b => RefPredicate.Equals(Ref.Branch(b)))
 
       val tags =
         if (tlCiReleaseTags.value)

--- a/sonatype-ci-release/src/main/scala/org/typelevel/sbt/TypelevelSonatypeCiReleasePlugin.scala
+++ b/sonatype-ci-release/src/main/scala/org/typelevel/sbt/TypelevelSonatypeCiReleasePlugin.scala
@@ -26,10 +26,8 @@ object TypelevelSonatypeCiReleasePlugin extends AutoPlugin {
   object autoImport {
     lazy val tlCiReleaseTags = settingKey[Boolean](
       "Controls whether or not v-prefixed tags should be released from CI (default true)")
-    lazy val tlCiReleaseSnapshots = settingKey[Boolean](
-      "Controls whether or not snapshots should be released from CI (default: false)")
-    lazy val tlCiReleaseBranches =
-      settingKey[Seq[String]]("The branches in your repository to release from (default: [])")
+    lazy val tlCiReleaseSnapshotBranches = settingKey[Seq[String]](
+      "The branches in your repository to release snapshots from in CI (default: [])")
   }
 
   import autoImport._
@@ -40,7 +38,7 @@ object TypelevelSonatypeCiReleasePlugin extends AutoPlugin {
   override def trigger = noTrigger
 
   override def globalSettings =
-    Seq(tlCiReleaseTags := true, tlCiReleaseSnapshots := false, tlCiReleaseBranches := Seq())
+    Seq(tlCiReleaseTags := true, tlCiReleaseSnapshotBranches := Seq())
 
   override def buildSettings = Seq(
     githubWorkflowEnv ++= Map(
@@ -49,10 +47,7 @@ object TypelevelSonatypeCiReleasePlugin extends AutoPlugin {
     ),
     githubWorkflowPublishTargetBranches := {
       val snapshots =
-        if (tlCiReleaseSnapshots.value)
-          tlCiReleaseBranches.value.map(b => RefPredicate.Equals(Ref.Branch(b)))
-        else
-          Seq.empty
+        tlCiReleaseSnapshotBranches.value.map(b => RefPredicate.Equals(Ref.Branch(b)))
 
       val tags =
         if (tlCiReleaseTags.value)

--- a/sonatype-ci-release/src/main/scala/org/typelevel/sbt/TypelevelSonatypeCiReleasePlugin.scala
+++ b/sonatype-ci-release/src/main/scala/org/typelevel/sbt/TypelevelSonatypeCiReleasePlugin.scala
@@ -46,7 +46,7 @@ object TypelevelSonatypeCiReleasePlugin extends AutoPlugin {
       "SONATYPE_PASSWORD" -> s"$${{ secrets.SONATYPE_PASSWORD }}"
     ),
     githubWorkflowPublishTargetBranches := {
-      val snapshots =
+      val branches =
         tlCiReleaseBranches.value.map(b => RefPredicate.Equals(Ref.Branch(b)))
 
       val tags =
@@ -55,7 +55,7 @@ object TypelevelSonatypeCiReleasePlugin extends AutoPlugin {
         else
           Seq.empty
 
-      tags ++ snapshots
+      tags ++ branches
     },
     githubWorkflowTargetTags += "v*",
     githubWorkflowPublish := Seq(


### PR DESCRIPTION
Two changes here:
1. Add a `tlCiReleaseTags` option, default `true`. This is so you can disable releasing tags from CI, good for projects like CE that may want CI snapshots but not CI tags.
2. Merge the `tlCiReleaseSnapshots` and `tlCiReleaseBranches` into a single setting `tlCiReleaseSnapshotBranches`, where you directly specify the branches you want snapshots from. Default is empty, which causes no snapshots to be released.