### PR TITLE
Introduce `tlCrossRootProject`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
         os: [ubuntu-latest]
         scala: [2.12.15]
         java: [temurin@8]
+        ci: [ciJVM]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -58,13 +59,13 @@ jobs:
       - name: Check that workflows are up to date
         run: sbt ++${{ matrix.scala }} githubWorkflowCheck
 
-      - run: sbt ++${{ matrix.scala }} ci
+      - run: sbt ++${{ matrix.scala }} '${{ matrix.ci }}'
 
       - name: Make target directories
-        run: mkdir -p github/target kernel/target versioning/target ci-release/target target ci-signing/target mima/target no-publish/target sonatype/target ci/target sonatype-ci-release/target core/target settings/target project/target
+        run: mkdir -p github/target kernel/target versioning/target ci-release/target target .js/target ci-signing/target mima/target .jvm/target .native/target no-publish/target sonatype/target ci/target sonatype-ci-release/target core/target settings/target project/target
 
       - name: Compress target directories
-        run: tar cf targets.tar github/target kernel/target versioning/target ci-release/target target ci-signing/target mima/target no-publish/target sonatype/target ci/target sonatype-ci-release/target core/target settings/target project/target
+        run: tar cf targets.tar github/target kernel/target versioning/target ci-release/target target .js/target ci-signing/target mima/target .jvm/target .native/target no-publish/target sonatype/target ci/target sonatype-ci-release/target core/target settings/target project/target
 
       - name: Upload target directories
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Check that workflows are up to date
         run: sbt ++${{ matrix.scala }} githubWorkflowCheck
 
+      - name: Check headers and formatting
+        run: sbt ++${{ matrix.scala }} 'project /' headerCheckAll scalafmtCheckAll scalafmtSbtCheck
+
       - run: sbt ++${{ matrix.scala }} '${{ matrix.ci }}'
 
       - name: Make target directories

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,6 @@ jobs:
       - name: Check that workflows are up to date
         run: sbt ++${{ matrix.scala }} githubWorkflowCheck
 
-      - name: Check headers and formatting
-        run: sbt ++${{ matrix.scala }} 'project /' headerCheckAll scalafmtCheckAll scalafmtSbtCheck
-
       - run: sbt ++${{ matrix.scala }} '${{ matrix.ci }}'
 
       - name: Make target directories

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,9 @@ jobs:
 
       - run: sbt ++${{ matrix.scala }} ci
 
+      - name: Make target directories
+        run: mkdir -p github/target kernel/target versioning/target ci-release/target target ci-signing/target mima/target no-publish/target sonatype/target ci/target sonatype-ci-release/target core/target settings/target project/target
+
       - name: Compress target directories
         run: tar cf targets.tar github/target kernel/target versioning/target ci-release/target target ci-signing/target mima/target no-publish/target sonatype/target ci/target sonatype-ci-release/target core/target settings/target project/target
 

--- a/build.sbt
+++ b/build.sbt
@@ -105,7 +105,7 @@ lazy val ci = project
   .enablePlugins(SbtPlugin)
   .settings(
     name := "sbt-typelevel-ci"
-  )
+  ).dependsOn(noPublish)
 
 lazy val ciRelease = project
   .in(file("ci-release"))

--- a/build.sbt
+++ b/build.sbt
@@ -15,22 +15,19 @@ ThisBuild / developers := List(
   tlGitHubDev("djspiewak", "Daniel Spiewak")
 )
 
-lazy val root = project
-  .in(file("."))
-  .enablePlugins(NoPublishPlugin)
-  .aggregate(
-    kernel,
-    noPublish,
-    settings,
-    github,
-    versioning,
-    mima,
-    sonatype,
-    ciSigning,
-    sonatypeCiRelease,
-    ci,
-    core,
-    ciRelease)
+lazy val root = tlCrossRootProject.aggregate(
+  kernel,
+  noPublish,
+  settings,
+  github,
+  versioning,
+  mima,
+  sonatype,
+  ciSigning,
+  sonatypeCiRelease,
+  ci,
+  core,
+  ciRelease)
 
 lazy val kernel = project
   .in(file("kernel"))
@@ -105,7 +102,8 @@ lazy val ci = project
   .enablePlugins(SbtPlugin)
   .settings(
     name := "sbt-typelevel-ci"
-  ).dependsOn(noPublish)
+  )
+  .dependsOn(noPublish)
 
 lazy val ciRelease = project
   .in(file("ci-release"))

--- a/build.sbt
+++ b/build.sbt
@@ -81,6 +81,7 @@ lazy val sonatype = project
   .settings(
     name := "sbt-typelevel-sonatype"
   )
+  .dependsOn(kernel)
 
 lazy val ciSigning = project
   .in(file("ci-signing"))
@@ -103,7 +104,7 @@ lazy val ci = project
   .settings(
     name := "sbt-typelevel-ci"
   )
-  .dependsOn(noPublish)
+  .dependsOn(noPublish, kernel)
 
 lazy val ciRelease = project
   .in(file("ci-release"))

--- a/ci/build.sbt
+++ b/ci/build.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("com.codecommit" % "sbt-github-actions" % "0.14.2")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.0.1")
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.1.0")
-addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.1.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.0.0") // scala-steward:off
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.0") // scala-steward:off

--- a/ci/build.sbt
+++ b/ci/build.sbt
@@ -1,2 +1,4 @@
 addSbtPlugin("com.codecommit" % "sbt-github-actions" % "0.14.2")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.0.1")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.1.0")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.1.0")

--- a/ci/build.sbt
+++ b/ci/build.sbt
@@ -1,4 +1,2 @@
 addSbtPlugin("com.codecommit" % "sbt-github-actions" % "0.14.2")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.0.1")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.0.0") // scala-steward:off
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.0") // scala-steward:off

--- a/ci/src/main/scala/org/typelevel/sbt/CrossRootProject.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/CrossRootProject.scala
@@ -18,7 +18,6 @@ package org.typelevel.sbt
 
 import sbt._
 import sbtghactions.GenerativePlugin.autoImport._
-import TypelevelKernelPlugin.autoImport._
 import TypelevelCiPlugin.ciCommands
 import TypelevelKernelPlugin.mkCommand
 

--- a/ci/src/main/scala/org/typelevel/sbt/CrossRootProject.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/CrossRootProject.scala
@@ -109,7 +109,11 @@ object TypelevelCiCrossPlugin extends AutoPlugin {
   override def requires = TypelevelCiPlugin
 
   override def buildSettings = Seq(
-    githubWorkflowBuild := Seq(WorkflowStep.Sbt(List(s"$${{ matrix.ci }}"))),
+    githubWorkflowBuild ~= { steps =>
+      // remove the usual ci step and replace with matrix ci
+      steps.diff(Seq(WorkflowStep.Sbt(List("ci")))) :+
+        WorkflowStep.Sbt(List(s"$${{ matrix.ci }}"))
+    },
     githubWorkflowBuildMatrixAdditions += "ci" -> Nil
   )
 }

--- a/ci/src/main/scala/org/typelevel/sbt/CrossRootProject.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/CrossRootProject.scala
@@ -17,9 +17,7 @@
 package org.typelevel.sbt
 
 import sbt._
-import org.scalajs.sbtplugin.ScalaJSPlugin
 import sbtghactions.GenerativePlugin.autoImport._
-import scala.scalanative.sbtplugin.ScalaNativePlugin
 
 /**
  * Simultaneously creates a `root`, `rootJVM`, `rootJS`, and `rootNative` project, and
@@ -70,11 +68,12 @@ final class CrossRootProject private (
     aggregateImpl(projects.flatMap(_.componentProjects): _*)
 
   private def aggregateImpl(projects: Project*): CrossRootProject = {
-
-    val jsProjects = projects.filter(p => Plugins.satisfied(p.plugins, Set(ScalaJSPlugin)))
+    val jsProjects =
+      projects.filter(_.plugins.toString.contains("org.scalajs.sbtplugin.ScalaJSPlugin"))
 
     val nativeProjects =
-      projects.filter(p => Plugins.satisfied(p.plugins, Set(ScalaNativePlugin)))
+      projects.filter(
+        _.plugins.toString.contains("scala.scalanative.sbtplugin.ScalaNativePlugin"))
 
     val jvmProjects = projects.diff(jsProjects).diff(nativeProjects)
 

--- a/ci/src/main/scala/org/typelevel/sbt/CrossRootProject.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/CrossRootProject.scala
@@ -17,7 +17,6 @@
 package org.typelevel.sbt
 
 import sbt._
-import sbtcrossproject.CrossProject
 import org.scalajs.sbtplugin.ScalaJSPlugin
 import sbtghactions.GenerativePlugin.autoImport._
 import scala.scalanative.sbtplugin.ScalaNativePlugin
@@ -67,10 +66,10 @@ final class CrossRootProject private (
       rootNative.disablePlugins(ps: _*)
     )
 
-  def aggregate(projects: CrossProject*)(implicit dummy: DummyImplicit): CrossRootProject =
-    aggregate(projects.flatMap(_.componentProjects): _*)
+  def aggregate(projects: CompositeProject*): CrossRootProject =
+    aggregateImpl(projects.flatMap(_.componentProjects): _*)
 
-  def aggregate(projects: Project*): CrossRootProject = {
+  private def aggregateImpl(projects: Project*): CrossRootProject = {
 
     val jsProjects = projects.filter(p => Plugins.satisfied(p.plugins, Set(ScalaJSPlugin)))
 

--- a/ci/src/main/scala/org/typelevel/sbt/CrossRootProject.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/CrossRootProject.scala
@@ -156,6 +156,12 @@ object TypelevelCiJSPlugin extends AutoPlugin {
   ) ++ Seq(
     githubWorkflowBuildMatrixAdditions ~= { matrix =>
       matrix.updated("ci", matrix("ci") ::: "ciJS" :: Nil)
+    },
+    githubWorkflowBuildMatrixExclusions ++= {
+      githubWorkflowJavaVersions
+        .value
+        .tail
+        .map(java => MatrixExclude(Map("ci" -> "ciJS", "java" -> java.render)))
     }
   )
 }
@@ -175,6 +181,12 @@ object TypelevelCiNativePlugin extends AutoPlugin {
   ) ++ Seq(
     githubWorkflowBuildMatrixAdditions ~= { matrix =>
       matrix.updated("ci", matrix("ci") ::: "ciNative" :: Nil)
+    },
+    githubWorkflowBuildMatrixExclusions ++= {
+      githubWorkflowJavaVersions
+        .value
+        .tail
+        .map(java => MatrixExclude(Map("ci" -> "ciNative", "java" -> java.render)))
     }
   )
 }

--- a/ci/src/main/scala/org/typelevel/sbt/CrossRootProject.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/CrossRootProject.scala
@@ -105,6 +105,9 @@ object CrossRootProject {
   ).enablePlugins(NoPublishPlugin, TypelevelCiCrossPlugin)
 }
 
+/**
+ * This plugin is used internally by CrossRootProject.
+ */
 object TypelevelCiCrossPlugin extends AutoPlugin {
   override def requires = TypelevelCiPlugin
 
@@ -117,6 +120,8 @@ object TypelevelCiCrossPlugin extends AutoPlugin {
     githubWorkflowBuildMatrixAdditions += "ci" -> Nil
   )
 }
+
+// The following plugins are used internally to support CrossRootProject.
 
 object TypelevelCiJVMPlugin extends AutoPlugin {
   override def requires = TypelevelCiCrossPlugin

--- a/ci/src/main/scala/org/typelevel/sbt/CrossRootProject.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/CrossRootProject.scala
@@ -20,6 +20,7 @@ import sbt._
 import sbtghactions.GenerativePlugin.autoImport._
 import TypelevelKernelPlugin.autoImport._
 import TypelevelCiPlugin.ciCommands
+import TypelevelKernelPlugin.mkCommand
 
 /**
  * Simultaneously creates a `root`, `rootJVM`, `rootJS`, and `rootNative` project, and
@@ -128,7 +129,7 @@ object TypelevelCiJVMPlugin extends AutoPlugin {
   override def requires = TypelevelCiCrossPlugin
 
   override def buildSettings: Seq[Setting[_]] =
-    addCommandAlias("ciJVM", ciJVMCommands.mkCommand) ++ Seq(
+    addCommandAlias("ciJVM", mkCommand(ciJVMCommands)) ++ Seq(
       githubWorkflowBuildMatrixAdditions ~= { matrix =>
         matrix.updated("ci", matrix("ci") ::: "ciJVM" :: Nil)
       }
@@ -141,7 +142,7 @@ object TypelevelCiJSPlugin extends AutoPlugin {
   override def requires = TypelevelCiCrossPlugin
 
   override def buildSettings: Seq[Setting[_]] =
-    addCommandAlias("ciJS", ciJSCommands.mkCommand) ++ Seq(
+    addCommandAlias("ciJS", mkCommand(ciJSCommands)) ++ Seq(
       githubWorkflowBuildMatrixAdditions ~= { matrix =>
         matrix.updated("ci", matrix("ci") ::: "ciJS" :: Nil)
       },
@@ -163,7 +164,7 @@ object TypelevelCiNativePlugin extends AutoPlugin {
   override def requires = TypelevelCiCrossPlugin
 
   override def buildSettings: Seq[Setting[_]] =
-    addCommandAlias("ciNative", ciNativeCommands.mkCommand) ++ Seq(
+    addCommandAlias("ciNative", mkCommand(ciNativeCommands)) ++ Seq(
       githubWorkflowBuildMatrixAdditions ~= { matrix =>
         matrix.updated("ci", matrix("ci") ::: "ciNative" :: Nil)
       },

--- a/ci/src/main/scala/org/typelevel/sbt/CrossRootProject.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/CrossRootProject.scala
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.sbt
+
+import sbt._
+import sbtcrossproject.CrossProject
+import org.scalajs.sbtplugin.ScalaJSPlugin
+import sbtghactions.GenerativePlugin.autoImport._
+import scala.scalanative.sbtplugin.ScalaNativePlugin
+
+/**
+ * Simultaneously creates a `root`, `rootJVM`, `rootJS`, and `rootNative` project, and
+ * automatically enables the `NoPublishPlugin`.
+ */
+final class CrossRootProject private (
+    val root: Project,
+    val rootJVM: Project,
+    val rootJS: Project,
+    val rootNative: Project
+) extends CompositeProject {
+
+  override def componentProjects: Seq[Project] = Seq(root, rootJVM, rootJS, rootNative)
+
+  def settings(ss: Def.SettingsDefinition*): CrossRootProject =
+    new CrossRootProject(
+      root.settings(ss: _*),
+      rootJVM.settings(ss: _*),
+      rootJS.settings(ss: _*),
+      rootNative.settings(ss: _*)
+    )
+
+  def configure(transforms: (Project => Project)*): CrossRootProject =
+    new CrossRootProject(
+      root.configure(transforms: _*),
+      rootJVM.configure(transforms: _*),
+      rootJS.configure(transforms: _*),
+      rootNative.configure(transforms: _*)
+    )
+
+  def enablePlugins(ns: Plugins*): CrossRootProject =
+    new CrossRootProject(
+      root.enablePlugins(ns: _*),
+      rootJVM.enablePlugins(ns: _*),
+      rootJS.enablePlugins(ns: _*),
+      rootNative.enablePlugins(ns: _*)
+    )
+
+  def disablePlugins(ps: AutoPlugin*): CrossRootProject =
+    new CrossRootProject(
+      root.disablePlugins(ps: _*),
+      rootJVM.disablePlugins(ps: _*),
+      rootJS.disablePlugins(ps: _*),
+      rootNative.disablePlugins(ps: _*)
+    )
+
+  def aggregate(projects: CrossProject*)(implicit dummy: DummyImplicit): CrossRootProject =
+    aggregate(projects.flatMap(_.componentProjects): _*)
+
+  def aggregate(projects: Project*): CrossRootProject = {
+
+    val jsProjects = projects.filter(p => Plugins.satisfied(p.plugins, Set(ScalaJSPlugin)))
+
+    val nativeProjects =
+      projects.filter(p => Plugins.satisfied(p.plugins, Set(ScalaNativePlugin)))
+
+    val jvmProjects = projects.diff(jsProjects).diff(nativeProjects)
+
+    new CrossRootProject(
+      root.aggregate(projects.map(_.project): _*),
+      if (jvmProjects.nonEmpty)
+        rootJVM.aggregate(jvmProjects.map(_.project): _*).enablePlugins(TypelevelCiJVMPlugin)
+      else rootJVM,
+      if (jsProjects.nonEmpty)
+        rootJS.aggregate(jsProjects.map(_.project): _*).enablePlugins(TypelevelCiJSPlugin)
+      else rootJS,
+      if (nativeProjects.nonEmpty)
+        rootNative
+          .aggregate(nativeProjects.map(_.project): _*)
+          .enablePlugins(TypelevelCiNativePlugin)
+      else rootNative
+    )
+  }
+
+}
+
+object CrossRootProject {
+  private[sbt] def apply(): CrossRootProject = new CrossRootProject(
+    Project("root", file(".")),
+    Project("rootJVM", file(".jvm")),
+    Project("rootJS", file(".js")),
+    Project("rootNative", file(".native"))
+  ).enablePlugins(NoPublishPlugin, TypelevelCiCrossPlugin)
+}
+
+object TypelevelCiCrossPlugin extends AutoPlugin {
+  override def requires = TypelevelCiPlugin
+
+  override def buildSettings = Seq(
+    githubWorkflowBuild := Seq(WorkflowStep.Sbt(List(s"$${{ matrix.ci }}"))),
+    githubWorkflowBuildMatrixAdditions += "ci" -> Nil,
+    githubWorkflowGeneratedUploadSteps ~= { steps =>
+      // hack hack hack until upstreamed
+      // workaround for https://github.com/djspiewak/sbt-github-actions/pull/66
+      val mkdirStep = steps.headOption match {
+        case Some(
+              WorkflowStep
+                .Run(command :: _, Some("Compress target directories"), _, _, _, _)) =>
+          WorkflowStep.Run(
+            commands = List(command.replace("tar cf targets.tar", "mkdir -p")),
+            name = Some("Make target directories")
+          )
+        case _ => sys.error("Can't generate make target dirs workflow step")
+      }
+      mkdirStep +: steps
+    }
+  )
+}
+
+object TypelevelCiJVMPlugin extends AutoPlugin {
+  override def requires = TypelevelCiCrossPlugin
+
+  override def buildSettings: Seq[Setting[_]] = addCommandAlias(
+    "ciJVM",
+    List(
+      "project rootJVM",
+      "clean",
+      "test",
+      "mimaReportBinaryIssues"
+    ).mkString("; ", "; ", "")
+  ) ++ Seq(
+    githubWorkflowBuildMatrixAdditions ~= { matrix =>
+      matrix.updated("ci", matrix("ci") ::: "ciJVM" :: Nil)
+    }
+  )
+}
+
+object TypelevelCiJSPlugin extends AutoPlugin {
+  override def requires = TypelevelCiCrossPlugin
+
+  override def buildSettings: Seq[Setting[_]] = addCommandAlias(
+    "ciJS",
+    List(
+      "project rootJS",
+      "clean",
+      "Test/fastOptJS",
+      "test",
+      "mimaReportBinaryIssues"
+    ).mkString("; ", "; ", "")
+  ) ++ Seq(
+    githubWorkflowBuildMatrixAdditions ~= { matrix =>
+      matrix.updated("ci", matrix("ci") ::: "ciJS" :: Nil)
+    }
+  )
+}
+
+object TypelevelCiNativePlugin extends AutoPlugin {
+  override def requires = TypelevelCiCrossPlugin
+
+  override def buildSettings: Seq[Setting[_]] = addCommandAlias(
+    "ciNative",
+    List(
+      "project rootNative",
+      "clean",
+      "Test/nativeLink",
+      "test",
+      "mimaReportBinaryIssues"
+    ).mkString("; ", "; ", "")
+  ) ++ Seq(
+    githubWorkflowBuildMatrixAdditions ~= { matrix =>
+      matrix.updated("ci", matrix("ci") ::: "ciNative" :: Nil)
+    }
+  )
+}

--- a/ci/src/main/scala/org/typelevel/sbt/CrossRootProject.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/CrossRootProject.scala
@@ -110,22 +110,7 @@ object TypelevelCiCrossPlugin extends AutoPlugin {
 
   override def buildSettings = Seq(
     githubWorkflowBuild := Seq(WorkflowStep.Sbt(List(s"$${{ matrix.ci }}"))),
-    githubWorkflowBuildMatrixAdditions += "ci" -> Nil,
-    githubWorkflowGeneratedUploadSteps ~= { steps =>
-      // hack hack hack until upstreamed
-      // workaround for https://github.com/djspiewak/sbt-github-actions/pull/66
-      val mkdirStep = steps.headOption match {
-        case Some(
-              WorkflowStep
-                .Run(command :: _, Some("Compress target directories"), _, _, _, _)) =>
-          WorkflowStep.Run(
-            commands = List(command.replace("tar cf targets.tar", "mkdir -p")),
-            name = Some("Make target directories")
-          )
-        case _ => sys.error("Can't generate make target dirs workflow step")
-      }
-      mkdirStep +: steps
-    }
+    githubWorkflowBuildMatrixAdditions += "ci" -> Nil
   )
 }
 

--- a/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
@@ -21,6 +21,7 @@ import sbtghactions.GenerativePlugin
 import sbtghactions.GitHubActionsPlugin
 import sbtghactions.GenerativePlugin.autoImport._
 import com.typesafe.tools.mima.plugin.MimaPlugin
+import TypelevelKernelPlugin.mkCommand
 
 object TypelevelCiPlugin extends AutoPlugin {
 
@@ -31,10 +32,8 @@ object TypelevelCiPlugin extends AutoPlugin {
     def tlCrossRootProject: CrossRootProject = CrossRootProject()
   }
 
-  import TypelevelKernelPlugin.autoImport._
-
   override def buildSettings =
-    addCommandAlias("ci", ciCommands.mkCommand) ++ Seq(
+    addCommandAlias("ci", mkCommand(ciCommands)) ++ Seq(
       githubWorkflowPublishTargetBranches := Seq(),
       githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("ci"))),
       githubWorkflowJavaVersions := Seq(JavaSpec.temurin("8")),

--- a/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
@@ -40,16 +40,15 @@ object TypelevelCiPlugin extends AutoPlugin {
       githubWorkflowGeneratedUploadSteps ~= { steps =>
         // hack hack hack until upstreamed
         // workaround for https://github.com/djspiewak/sbt-github-actions/pull/66
-        steps.headOption match {
-          case Some(
-                WorkflowStep
-                  .Run(command :: _, _, Some("Compress target directories"), _, _, _)) =>
+        steps.flatMap {
+          case compressStep @ WorkflowStep
+                .Run(command :: _, _, Some("Compress target directories"), _, _, _) =>
             val mkdirStep = WorkflowStep.Run(
               commands = List(command.replace("tar cf targets.tar", "mkdir -p")),
               name = Some("Make target directories")
             )
-            mkdirStep +: steps
-          case _ => steps
+            List(mkdirStep, compressStep)
+          case step => List(step)
         }
       }
     )

--- a/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
@@ -27,6 +27,10 @@ object TypelevelCiPlugin extends AutoPlugin {
   override def requires = GitHubActionsPlugin && GenerativePlugin && MimaPlugin
   override def trigger = allRequirements
 
+  object autoImport {
+    def tlCrossRootProject: CrossRootProject = CrossRootProject()
+  }
+
   override def buildSettings =
     addCommandAlias(
       "ci",

--- a/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
@@ -31,16 +31,10 @@ object TypelevelCiPlugin extends AutoPlugin {
     def tlCrossRootProject: CrossRootProject = CrossRootProject()
   }
 
+  import TypelevelKernelPlugin.autoImport._
+
   override def buildSettings =
-    addCommandAlias(
-      "ci",
-      List(
-        "project /",
-        "clean",
-        "test",
-        "mimaReportBinaryIssues"
-      ).mkString("; ", "; ", "")
-    ) ++ Seq(
+    addCommandAlias("ci", ciCommands.mkCommand) ++ Seq(
       githubWorkflowPublishTargetBranches := Seq(),
       githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("ci"))),
       githubWorkflowJavaVersions := Seq(JavaSpec.temurin("8")),
@@ -60,5 +54,12 @@ object TypelevelCiPlugin extends AutoPlugin {
         }
       }
     )
+
+  val ciCommands = List(
+    "project /",
+    "clean",
+    "test",
+    "mimaReportBinaryIssues"
+  )
 
 }

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -1,4 +1,3 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.1.0")
-addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.1.0")

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -1,2 +1,4 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.0")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.1.0")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.1.0")

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -1,3 +1,2 @@
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.1.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.0")

--- a/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
+++ b/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
@@ -64,7 +64,7 @@ object TypelevelPlugin extends AutoPlugin {
         java <- githubWorkflowJavaVersions.value.tail
       } yield MatrixExclude(Map("scala" -> scala, "java" -> java.render))
     }
-  ) ++ replaceCommandAlias(
+  ) ++ tlReplaceCommandAlias(
     "ci",
     (ciCommands.head :: fmtCheckCommands ::: ciCommands.tail).mkCommand) ++ Seq(
     githubWorkflowBuild := {

--- a/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
+++ b/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
@@ -19,8 +19,8 @@ package org.typelevel.sbt
 import sbt._, Keys._
 import sbtghactions.GenerativePlugin
 import sbtghactions.GitHubActionsPlugin
-
 import de.heikoseeberger.sbtheader.AutomateHeaderPlugin
+import TypelevelCiPlugin.ciCommands
 
 object TypelevelPlugin extends AutoPlugin {
 
@@ -66,8 +66,7 @@ object TypelevelPlugin extends AutoPlugin {
     }
   ) ++ replaceCommandAlias(
     "ci",
-    "; project /; headerCheckAll; scalafmtCheckAll; scalafmtSbtCheck; clean; test; mimaReportBinaryIssues"
-  ) ++ Seq(
+    (ciCommands.head :: fmtCheckCommands ::: ciCommands.tail).mkCommand) ++ Seq(
     githubWorkflowBuild := {
       val step =
         if (githubWorkflowBuildMatrixAdditions.value.keySet.contains("ci"))
@@ -86,4 +85,5 @@ object TypelevelPlugin extends AutoPlugin {
 
   override def projectSettings = AutomateHeaderPlugin.projectSettings
 
+  val fmtCheckCommands = List("headerCheckAll", "scalafmtCheckAll", "scalafmtSbtCheck")
 }

--- a/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
+++ b/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
@@ -67,6 +67,21 @@ object TypelevelPlugin extends AutoPlugin {
   ) ++ replaceCommandAlias(
     "ci",
     "; project /; headerCheckAll; scalafmtCheckAll; scalafmtSbtCheck; clean; test; mimaReportBinaryIssues"
+  ) ++ Seq(
+    githubWorkflowBuild := {
+      val step =
+        if (githubWorkflowBuildMatrixAdditions.value.keySet.contains("ci"))
+          // the CI has been crossed for JVM/JS/Native
+          // Trying to detect and replace aliases conditionally seems scary so we just add an extra step
+          Seq(
+            WorkflowStep.Sbt(
+              List("project /", "headerCheckAll", "scalafmtCheckAll", "scalafmtSbtCheck"),
+              name = Some("Check headers and formatting"))
+          )
+        else
+          Seq.empty
+      step ++ githubWorkflowBuild.value
+    }
   )
 
   override def projectSettings = AutomateHeaderPlugin.projectSettings

--- a/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
+++ b/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
@@ -21,6 +21,7 @@ import sbtghactions.GenerativePlugin
 import sbtghactions.GitHubActionsPlugin
 import de.heikoseeberger.sbtheader.AutomateHeaderPlugin
 import TypelevelCiPlugin.ciCommands
+import TypelevelKernelPlugin.mkCommand
 
 object TypelevelPlugin extends AutoPlugin {
 
@@ -64,7 +65,7 @@ object TypelevelPlugin extends AutoPlugin {
         java <- githubWorkflowJavaVersions.value.tail
       } yield MatrixExclude(Map("scala" -> scala, "java" -> java.render))
     }
-  ) ++ tlReplaceCommandAlias("ci", (fmtCheckCommands ::: ciCommands.tail).mkCommand)
+  ) ++ tlReplaceCommandAlias("ci", mkCommand(fmtCheckCommands ::: ciCommands.tail))
 
   override def projectSettings = AutomateHeaderPlugin.projectSettings
 
@@ -82,19 +83,19 @@ object TypelevelJVMPlugin extends AutoPlugin {
   override def requires = TypelevelCiJVMPlugin
   override def trigger = allRequirements
   override def buildSettings =
-    tlReplaceCommandAlias("ciJVM", (fmtCheckCommands ++ ciJVMCommands).mkCommand)
+    tlReplaceCommandAlias("ciJVM", mkCommand(fmtCheckCommands ++ ciJVMCommands))
 }
 
 object TypelevelJSPlugin extends AutoPlugin {
   override def requires = TypelevelCiJSPlugin
   override def trigger = allRequirements
   override def buildSettings =
-    tlReplaceCommandAlias("ciJS", (fmtCheckCommands ++ ciJSCommands).mkCommand)
+    tlReplaceCommandAlias("ciJS", mkCommand(fmtCheckCommands ++ ciJSCommands))
 }
 
 object TypelevelNativePlugin extends AutoPlugin {
   override def requires = TypelevelCiNativePlugin
   override def trigger = allRequirements
   override def buildSettings =
-    tlReplaceCommandAlias("ciNative", (fmtCheckCommands ++ ciNativeCommands).mkCommand)
+    tlReplaceCommandAlias("ciNative", mkCommand(fmtCheckCommands ++ ciNativeCommands))
 }

--- a/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
+++ b/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
@@ -64,9 +64,7 @@ object TypelevelPlugin extends AutoPlugin {
         java <- githubWorkflowJavaVersions.value.tail
       } yield MatrixExclude(Map("scala" -> scala, "java" -> java.render))
     }
-  ) ++ tlReplaceCommandAlias(
-    "ci",
-    (ciCommands.head :: fmtCheckCommands ::: ciCommands.tail).mkCommand)
+  ) ++ tlReplaceCommandAlias("ci", (fmtCheckCommands ::: ciCommands.tail).mkCommand)
 
   override def projectSettings = AutomateHeaderPlugin.projectSettings
 

--- a/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
+++ b/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
@@ -26,12 +26,15 @@ object TypelevelKernelPlugin extends AutoPlugin {
 
   object autoImport {
     lazy val tlIsScala3 = settingKey[Boolean]("True if building with Scala 3")
+
     def replaceCommandAlias(name: String, contents: String): Seq[Setting[State => State]] =
       Seq(GlobalScope / onLoad ~= { (f: State => State) =>
         f andThen { s: State =>
           BasicCommands.addAlias(BasicCommands.removeAlias(s, name), name, contents)
         }
       })
+
+    implicit def tlCommandOps(commands: List[String]): TlCommandOps = new TlCommandOps(commands)
   }
 
   import autoImport._
@@ -41,6 +44,10 @@ object TypelevelKernelPlugin extends AutoPlugin {
   )
 
   override def buildSettings =
-    addCommandAlias("releaseLocal", "; reload; project /; +publishLocal")
+    addCommandAlias("releaseLocal", List("reload", "project /", "+publishLocal").mkCommand)
+
+  final class TlCommandOps(commands: List[String]) {
+    def mkCommand: String = commands.mkString("; ", "; ", "")
+  }
 
 }

--- a/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
+++ b/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
@@ -27,7 +27,7 @@ object TypelevelKernelPlugin extends AutoPlugin {
   object autoImport {
     lazy val tlIsScala3 = settingKey[Boolean]("True if building with Scala 3")
 
-    def replaceCommandAlias(name: String, contents: String): Seq[Setting[State => State]] =
+    def tlReplaceCommandAlias(name: String, contents: String): Seq[Setting[State => State]] =
       Seq(GlobalScope / onLoad ~= { (f: State => State) =>
         f andThen { s: State =>
           BasicCommands.addAlias(BasicCommands.removeAlias(s, name), name, contents)

--- a/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
+++ b/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
@@ -33,8 +33,6 @@ object TypelevelKernelPlugin extends AutoPlugin {
           BasicCommands.addAlias(BasicCommands.removeAlias(s, name), name, contents)
         }
       })
-
-    implicit def tlCommandOps(commands: List[String]): TlCommandOps = new TlCommandOps(commands)
   }
 
   import autoImport._
@@ -44,10 +42,8 @@ object TypelevelKernelPlugin extends AutoPlugin {
   )
 
   override def buildSettings =
-    addCommandAlias("releaseLocal", List("reload", "project /", "+publishLocal").mkCommand)
+    addCommandAlias("releaseLocal", mkCommand(List("reload", "project /", "+publishLocal")))
 
-  final class TlCommandOps(commands: List[String]) {
-    def mkCommand: String = commands.mkString("; ", "; ", "")
-  }
+  def mkCommand(commands: List[String]): String = commands.mkString("; ", "; ", "")
 
 }

--- a/sonatype/src/main/scala/org/typelevel/sbt/TypelevelSonatypePlugin.scala
+++ b/sonatype/src/main/scala/org/typelevel/sbt/TypelevelSonatypePlugin.scala
@@ -19,7 +19,7 @@ package org.typelevel.sbt
 import sbt._, Keys._
 import com.typesafe.tools.mima.plugin.MimaPlugin
 import xerial.sbt.Sonatype, Sonatype.autoImport._
-import TypelevelKernelPlugin.autoImport._
+import TypelevelKernelPlugin.mkCommand
 
 object TypelevelSonatypePlugin extends AutoPlugin {
 
@@ -38,12 +38,13 @@ object TypelevelSonatypePlugin extends AutoPlugin {
     Seq(tlSonatypeUseLegacyHost := true) ++
       addCommandAlias(
         "release",
-        List(
-          "reload",
-          "project /",
-          "+mimaReportBinaryIssues",
-          "+publish",
-          "sonatypeBundleReleaseIfRelevant").mkCommand
+        mkCommand(
+          List(
+            "reload",
+            "project /",
+            "+mimaReportBinaryIssues",
+            "+publish",
+            "sonatypeBundleReleaseIfRelevant"))
       )
 
   override def projectSettings = Seq(

--- a/sonatype/src/main/scala/org/typelevel/sbt/TypelevelSonatypePlugin.scala
+++ b/sonatype/src/main/scala/org/typelevel/sbt/TypelevelSonatypePlugin.scala
@@ -19,6 +19,7 @@ package org.typelevel.sbt
 import sbt._, Keys._
 import com.typesafe.tools.mima.plugin.MimaPlugin
 import xerial.sbt.Sonatype, Sonatype.autoImport._
+import TypelevelKernelPlugin.autoImport._
 
 object TypelevelSonatypePlugin extends AutoPlugin {
 
@@ -37,7 +38,13 @@ object TypelevelSonatypePlugin extends AutoPlugin {
     Seq(tlSonatypeUseLegacyHost := true) ++
       addCommandAlias(
         "release",
-        "; reload; project /; +mimaReportBinaryIssues; +publish; sonatypeBundleReleaseIfRelevant")
+        List(
+          "reload",
+          "project /",
+          "+mimaReportBinaryIssues",
+          "+publish",
+          "sonatypeBundleReleaseIfRelevant").mkCommand
+      )
 
   override def projectSettings = Seq(
     publishMavenStyle := true, // we want to do this unconditionally, even if publishing a plugin


### PR DESCRIPTION
Fixes https://github.com/typelevel/sbt-typelevel/issues/34.

This introduces a `tlCrossRootProject` helper for creating the "root" aggregate project. It:
1. Generates `root`, `rootJVM`, `rootJS`, and `rootNative` projects (all set to no-publish)
2. Automatically sorts any aggregated projects and cross-projects into their appropriate roots (`root` itself collects everything)
3. Adds an axis to the CI matrix for platform, but only adds jobs for platforms which are represented in the build

I've demonstrated/tested `tlCrossRootProject` on this build, where it adds a single `ciJVM` job to the matrix since there are no JS or native project in this build. (Note that we now also have a `rootJS` and `rootNative` project that are empty, just a small nuisance I hope.)