### PR TITLE
Take 2: fix CI release/snapshot race condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,5 +125,5 @@ jobs:
           echo "$PGP_PASSPHRASE" | gpg --pinentry-mode loopback --passphrase-fd 0 --import /tmp/signing-key.gpg
           (echo "$PGP_PASSPHRASE"; echo; echo) | gpg --command-fd 0 --pinentry-mode loopback --change-passphrase $(gpg --list-secret-keys --with-colons 2> /dev/null | grep '^sec:' | cut --delimiter ':' --fields 5 | tail -n 1)
 
-      - if: (startsWith(github.ref, 'refs/tags/v') && github.ref_type == 'tag') || (!startsWith(github.ref, 'refs/tags/v') && github.ref_type != 'tag')
-        run: sbt ++${{ matrix.scala }} release
+      - name: Publish project
+        run: sbt ++${{ matrix.scala }} +publish

--- a/sonatype-ci-release/src/main/scala/org/typelevel/sbt/TypelevelSonatypeCiReleasePlugin.scala
+++ b/sonatype-ci-release/src/main/scala/org/typelevel/sbt/TypelevelSonatypeCiReleasePlugin.scala
@@ -57,13 +57,6 @@ object TypelevelSonatypeCiReleasePlugin extends AutoPlugin {
 
       tags ++ branches
     },
-    githubWorkflowTargetTags += "v*",
-    githubWorkflowPublish := Seq(
-      WorkflowStep.Sbt(
-        List("release"),
-        cond = Some( // NEVER release a tag on a non-tag workflow run
-          "(startsWith(github.ref, 'refs/tags/v') && github.ref_type == 'tag') || (!startsWith(github.ref, 'refs/tags/v') && github.ref_type != 'tag')")
-      )
-    )
+    githubWorkflowTargetTags += "v*"
   )
 }

--- a/versioning/src/main/scala/org/typelevel/sbt/TypelevelVersioningPlugin.scala
+++ b/versioning/src/main/scala/org/typelevel/sbt/TypelevelVersioningPlugin.scala
@@ -52,8 +52,11 @@ object TypelevelVersioningPlugin extends AutoPlugin {
       // GITHUB_REF_TYPE is either `branch` or `tag`
       if (sys.env.get("GITHUB_REF_TYPE").exists(_ == "branch"))
         // we are running in a workflow job that was *not* triggered by a tag
-        // so, we pretend tags do not exist
-        Seq.empty
+        // so, we discard tags that would affect our versioning
+        git.gitCurrentTags.value.flatMap {
+          case V.Tag(_) => None
+          case other => Some(other)
+        }
       else
         git.gitCurrentTags.value
     },

--- a/versioning/src/main/scala/org/typelevel/sbt/TypelevelVersioningPlugin.scala
+++ b/versioning/src/main/scala/org/typelevel/sbt/TypelevelVersioningPlugin.scala
@@ -47,6 +47,16 @@ object TypelevelVersioningPlugin extends AutoPlugin {
       val dirty = git.gitUncommittedChanges.value
       !isVersionTagged && (tlUntaggedAreSnapshots.value || dirty)
     },
+    git.gitCurrentTags := {
+      // https://docs.github.com/en/actions/learn-github-actions/environment-variables
+      // GITHUB_REF_TYPE is either `branch` or `tag`
+      if (sys.env.get("GITHUB_REF_TYPE").exists(_ == "branch"))
+        // we are running in a workflow job that was *not* triggered by a tag
+        // so, we pretend tags do not exist
+        Seq.empty
+      else
+        git.gitCurrentTags.value
+    },
     version := {
       import scala.sys.process._
 


### PR DESCRIPTION
Fixes https://github.com/typelevel/sbt-typelevel/issues/42.

For context, this is the "race condition" where if a commit is pushed to GH with a tag and CI release is enabled for both tags and snapshots, two publish jobs will start simultaneously and both will have the identical (tagged) version. The workaround is to first push the commit and wait for its (snapshot) publish job to complete, then push the tag separately to trigger the second publish job.

Fixing this problem is also important for projects that may want CI release for snapshots but don't want CI release for tags, such as CE—there needs to be a way for the snapshot publish job to ignore the tags.

The solution here definitely makes me feel a bit queasy: it changes our versioning algorithm depending on the presence/value of an `GITHUB_REF_TYPE` environment variable, that indicates we are:
1. running in GH actions
2. running in a job that was _not_ triggered by a tag push

When both these conditions are true, the versioning algorithm ignores any "v" tags and adopts a hash version.

One of the nice things about this approach is that we still get one snapshot per push, in addition to any proper release. My previous solution was attempting to disable the snapshot publish job completely.

Thoughts?