### PR TITLE
Add `tlCursedVersions` setting

### DIFF
--- a/mima/src/main/scala/org/typelevel/sbt/TypelevelMimaPlugin.scala
+++ b/mima/src/main/scala/org/typelevel/sbt/TypelevelMimaPlugin.scala
@@ -59,6 +59,7 @@ object TypelevelMimaPlugin extends AutoPlugin {
           .map(v => V(v).getOrElse(sys.error(s"Version must be semver format: $v")))
         val previous = GitHelper
           .previousReleases()
+          .filterNot(tlCursedVersions.value)
           .filterNot(_.isPrerelease)
           .filter(v => introduced.forall(v >= _))
           .filter(current.mustBeBinCompatWith(_))

--- a/mima/src/main/scala/org/typelevel/sbt/TypelevelMimaPlugin.scala
+++ b/mima/src/main/scala/org/typelevel/sbt/TypelevelMimaPlugin.scala
@@ -59,7 +59,7 @@ object TypelevelMimaPlugin extends AutoPlugin {
           .map(v => V(v).getOrElse(sys.error(s"Version must be semver format: $v")))
         val previous = GitHelper
           .previousReleases()
-          .filterNot(tlCursedVersions.value)
+          .filterNot(tlCursedVersions.value.flatMap(V.unapply(_)).contains(_))
           .filterNot(_.isPrerelease)
           .filter(v => introduced.forall(v >= _))
           .filter(current.mustBeBinCompatWith(_))

--- a/mima/src/main/scala/org/typelevel/sbt/TypelevelMimaPlugin.scala
+++ b/mima/src/main/scala/org/typelevel/sbt/TypelevelMimaPlugin.scala
@@ -32,9 +32,15 @@ object TypelevelMimaPlugin extends AutoPlugin {
     lazy val tlVersionIntroduced =
       settingKey[Map[String, String]](
         "A map scalaBinaryVersion -> version e.g. Map('2.13' -> '1.5.2', '3' -> '1.7.1') used to indicate that a particular crossScalaVersions value was introduced in a given version (default: empty).")
+    lazy val tlCursedVersions =
+      settingKey[Set[String]]("Versions to exclude from bin-compat checks (default: empty)")
   }
 
   import autoImport._
+
+  override def buildSettings = Seq(
+    tlCursedVersions := Set.empty
+  )
 
   override def projectSettings = Seq[Setting[_]](
     tlVersionIntroduced := Map.empty,


### PR DESCRIPTION
For excluding mucked up or otherwise unpublished versions from mima checks. We've all been there. (Name subject to bikeshed.)