### PR TITLE
Automatically trigger ci-release plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ addSbtPlugin("org.typelevel" % "sbt-typelevel-ci-release" % "<version>")
 ThisBuild / tlBaseVersion := "0.4" // your current series x.y
 ThisBuild / developers +=
   tlGitHubDev("armanbilge", "Arman Bilge") // your GitHub handle and name
-enablePlugins(TypelevelCiReleasePlugin)
 ```
 
 Then, on GitHub set the following secrets on your repository:
@@ -120,7 +119,6 @@ Instead of using the super-plugins, for finer-grained control you can always add
   - Requires `PGP_SECRET` secret, with your base64-encoded PGP key
   - Optionally set the `PGP_PASSPHRASE` secret, but we do not recommend passphrase-protected keys for new projects. See discussion in [#9](https://github.com/typelevel/sbt-typelevel/discussions/9#discussioncomment-1251774).
 - **sbt-typelevel-ci-release**, `TypelevelCiReleasePlugin`: The super-plugin that sets you up with versioning, mima, signing, and sonatype publishing, all in GitHub actions.
-  - Must be activated with `enablePlugins(TypelevelCiReleasePlugin)`
 - **sbt-typelevel**, `TypelevelPlugin`: The super-super-plugin intended for bootstrapping the typical Typelevel project. Sets up CI release, scalac settings, headers, and formatting.
   - `tlFatalWarningsInCi` (setting): Convert compiler warnings into errors under CI builds (default: true).
 

--- a/build.sbt
+++ b/build.sbt
@@ -3,8 +3,6 @@ name := "sbt-typelevel"
 ThisBuild / tlBaseVersion := "0.4"
 ThisBuild / crossScalaVersions := Seq("2.12.15")
 
-enablePlugins(TypelevelCiReleasePlugin)
-
 ThisBuild / developers := List(
   tlGitHubDev("armanbilge", "Arman Bilge"),
   tlGitHubDev("rossabaker", "Ross A. Baker"),

--- a/ci-release/src/main/scala/org/typelevel/sbt/TypelevelCiReleasePlugin.scala
+++ b/ci-release/src/main/scala/org/typelevel/sbt/TypelevelCiReleasePlugin.scala
@@ -27,6 +27,6 @@ object TypelevelCiReleasePlugin extends AutoPlugin {
       TypelevelSonatypeCiReleasePlugin &&
       TypelevelCiSigningPlugin
 
-  override def trigger = noTrigger
+  override def trigger = allRequirements
 
 }

--- a/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
+++ b/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
@@ -28,9 +28,7 @@ object TypelevelPlugin extends AutoPlugin {
   override def requires =
     TypelevelKernelPlugin &&
       TypelevelSettingsPlugin &&
-      TypelevelVersioningPlugin &&
-      TypelevelMimaPlugin &&
-      TypelevelCiPlugin &&
+      TypelevelCiReleasePlugin &&
       GitHubActionsPlugin
 
   override def trigger = allRequirements

--- a/sonatype-ci-release/src/main/scala/org/typelevel/sbt/TypelevelSonatypeCiReleasePlugin.scala
+++ b/sonatype-ci-release/src/main/scala/org/typelevel/sbt/TypelevelSonatypeCiReleasePlugin.scala
@@ -35,7 +35,7 @@ object TypelevelSonatypeCiReleasePlugin extends AutoPlugin {
   override def requires = TypelevelSonatypePlugin && GitHubActionsPlugin &&
     GenerativePlugin
 
-  override def trigger = noTrigger
+  override def trigger = allRequirements
 
   override def globalSettings =
     Seq(tlCiReleaseTags := true, tlCiReleaseBranches := Seq())


### PR DESCRIPTION
Manual triggering was a pattern I copied from sbt-spiewak which doesn't make sense here.