### PR TITLE
Set scalafmt dialect to `scala212source3`

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,6 +1,6 @@
 version = 3.3.1
 
-runner.dialect = Scala212
+runner.dialect = scala212source3
 
 maxColumn = 96
 


### PR DESCRIPTION
Keep getting a warning about this. I assume it's because of our scalac flags.

Edit: this probably https://scalameta.org/scalafmt/docs/configuration.html#scala-2-with--xsource3