### PR TITLE
Make `previousReleases` strictly previous

### DIFF
--- a/kernel/src/main/scala/org/typelevel/sbt/kernel/GitHelper.scala
+++ b/kernel/src/main/scala/org/typelevel/sbt/kernel/GitHelper.scala
@@ -23,13 +23,15 @@ import scala.sys.process._
 object GitHelper {
 
   /**
+   * Returns a list of strictly previous releases (i.e. ignores tags on HEAD).
    * @param fromHead
    *   if `true`, only tags reachable from HEAD's history. If `false`, all tags in the repo.
    */
   def previousReleases(fromHead: Boolean = false): List[V] = {
     Try {
       val merged = if (fromHead) " --merged" else ""
-      s"git tag --list$merged".!!.split("\n").toList.map(_.trim).collect {
+      // --no-contains omits tags on HEAD
+      s"git tag --no-contains$merged".!!.split("\n").toList.map(_.trim).collect {
         case V.Tag(version) => version
       }
     }.getOrElse(List.empty).sorted.reverse

--- a/kernel/src/main/scala/org/typelevel/sbt/kernel/GitHelper.scala
+++ b/kernel/src/main/scala/org/typelevel/sbt/kernel/GitHelper.scala
@@ -29,9 +29,9 @@ object GitHelper {
    */
   def previousReleases(fromHead: Boolean = false): List[V] = {
     Try {
-      val merged = if (fromHead) " --merged" else ""
+      val merged = if (fromHead) " --merged HEAD" else ""
       // --no-contains omits tags on HEAD
-      s"git tag --no-contains$merged".!!.split("\n").toList.map(_.trim).collect {
+      s"git tag --no-contains HEAD$merged".!!.split("\n").toList.map(_.trim).collect {
         case V.Tag(version) => version
       }
     }.getOrElse(List.empty).sorted.reverse


### PR DESCRIPTION
Fixes #75 and fixes #76. A simple change to make the `previousReleases` strict, so it doesn't include any tags on the current commit as a previous release.