### PR TITLE
Don't generate headers automatically on compile

### DIFF
--- a/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
+++ b/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
@@ -19,7 +19,7 @@ package org.typelevel.sbt
 import sbt._, Keys._
 import org.typelevel.sbt.gha.GenerativePlugin
 import org.typelevel.sbt.gha.GitHubActionsPlugin
-import de.heikoseeberger.sbtheader.AutomateHeaderPlugin
+import de.heikoseeberger.sbtheader.HeaderPlugin
 
 object TypelevelPlugin extends AutoPlugin {
 
@@ -27,7 +27,8 @@ object TypelevelPlugin extends AutoPlugin {
     TypelevelKernelPlugin &&
       TypelevelSettingsPlugin &&
       TypelevelCiReleasePlugin &&
-      GitHubActionsPlugin
+      GitHubActionsPlugin &&
+      HeaderPlugin
 
   override def trigger = allRequirements
 
@@ -83,7 +84,5 @@ object TypelevelPlugin extends AutoPlugin {
       )
     )
   )
-
-  override def projectSettings = AutomateHeaderPlugin.projectSettings
 
 }

--- a/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
+++ b/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
@@ -85,4 +85,7 @@ object TypelevelPlugin extends AutoPlugin {
     )
   )
 
+  // override for bincompat
+  override def projectSettings = super.projectSettings
+
 }

--- a/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
+++ b/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
@@ -21,6 +21,8 @@ import org.typelevel.sbt.gha.GenerativePlugin
 import org.typelevel.sbt.gha.GitHubActionsPlugin
 import de.heikoseeberger.sbtheader.HeaderPlugin
 
+import scala.collection.immutable
+
 object TypelevelPlugin extends AutoPlugin {
 
   override def requires =
@@ -86,6 +88,6 @@ object TypelevelPlugin extends AutoPlugin {
   )
 
   // override for bincompat
-  override def projectSettings = super.projectSettings
+  override def projectSettings = immutable.Seq.empty
 
 }


### PR DESCRIPTION
Currently headers are automatically generated on compile. This is a bad default and leads to mishaps in CI like https://github.com/http4s/http4s/issues/5917.

Headers must now be manually generated with `headerCreateAll`. This is consistent with formatting, which is also invoked manually. All of this is covered in the existing `prePR` command, although perhaps we need a "lighter" alias that just does headers+formatting without clean-compiling like `prePR` does.