### PR TITLE
Only upload artifacts if publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,12 +72,15 @@ jobs:
         run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' doc
 
       - name: Make target directories
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
         run: mkdir -p github/target github-actions/target kernel/target versioning/target ci-release/target target .js/target mdocs/target site/target ci-signing/target mima/target .jvm/target .native/target no-publish/target sonatype/target ci/target sonatype-ci-release/target core/target settings/target project/target
 
       - name: Compress target directories
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
         run: tar cf targets.tar github/target github-actions/target kernel/target versioning/target ci-release/target target .js/target mdocs/target site/target ci-signing/target mima/target .jvm/target .native/target no-publish/target sonatype/target ci/target sonatype-ci-release/target core/target settings/target project/target
 
       - name: Upload target directories
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
         uses: actions/upload-artifact@v2
         with:
           name: target-${{ matrix.os }}-${{ matrix.scala }}-${{ matrix.java }}

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativePlugin.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativePlugin.scala
@@ -574,18 +574,21 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}
 
         val mkdir = WorkflowStep.Run(
           List(s"mkdir -p ${sanitized.mkString(" ")} project/target"),
-          name = Some("Make target directories"))
+          name = Some("Make target directories"),
+          cond = Some(publicationCond.value))
 
         val tar = WorkflowStep.Run(
           List(s"tar cf targets.tar ${sanitized.mkString(" ")} project/target"),
-          name = Some("Compress target directories"))
+          name = Some("Compress target directories"),
+          cond = Some(publicationCond.value))
 
         val upload = WorkflowStep.Use(
           UseRef.Public("actions", "upload-artifact", "v2"),
           name = Some(s"Upload target directories"),
           params = Map(
             "name" -> s"target-$${{ matrix.os }}-$${{ matrix.scala }}-$${{ matrix.java }}",
-            "path" -> "targets.tar")
+            "path" -> "targets.tar"),
+          cond = Some(publicationCond.value)
         )
 
         Seq(mkdir, tar, upload)
@@ -654,17 +657,6 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}
         githubWorkflowGeneratedCacheSteps.value.toList
     },
     githubWorkflowGeneratedCI := {
-      val publicationCondPre =
-        githubWorkflowPublishTargetBranches
-          .value
-          .map(compileBranchPredicate("github.ref", _))
-          .mkString("(", " || ", ")")
-
-      val publicationCond = githubWorkflowPublishCond.value match {
-        case Some(cond) => publicationCondPre + " && (" + cond + ")"
-        case None => publicationCondPre
-      }
-
       val uploadStepsOpt =
         if (githubWorkflowPublishTargetBranches
             .value
@@ -682,7 +674,7 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}
             githubWorkflowPublishPreamble.value.toList :::
             githubWorkflowPublish.value.toList :::
             githubWorkflowPublishPostamble.value.toList,
-          cond = Some(s"github.event_name != 'pull_request' && $publicationCond"),
+          cond = Some(publicationCond.value),
           scalas = List(scalaVersion.value),
           javas = List(githubWorkflowJavaVersions.value.head),
           needs = List("build")
@@ -712,6 +704,20 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}
         )) ++ publishJobOpt ++ githubWorkflowAddedJobs.value
     }
   )
+
+  private val publicationCond = Def setting {
+    val publicationCondPre =
+      githubWorkflowPublishTargetBranches
+        .value
+        .map(compileBranchPredicate("github.ref", _))
+        .mkString("(", " || ", ")")
+
+    val publicationCond = githubWorkflowPublishCond.value match {
+      case Some(cond) => publicationCondPre + " && (" + cond + ")"
+      case None => publicationCondPre
+    }
+    s"github.event_name != 'pull_request' && $publicationCond"
+  }
 
   private val generateCiContents = Def task {
     val sbt = if (githubWorkflowUseSbtThinClient.value) {


### PR DESCRIPTION
Fixes https://github.com/typelevel/sbt-typelevel/issues/89. Helps to mitigate https://github.com/typelevel/sbt-typelevel/issues/81.

Since the artifacts are only downloaded if the publish job runs, it makes sense that artifact upload should use the same condition.