### PR TITLE
Bump base version to 0.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "sbt-typelevel"
 
-ThisBuild / tlBaseVersion := "0.4"
+ThisBuild / tlBaseVersion := "0.5"
 ThisBuild / crossScalaVersions := Seq("2.12.15")
 ThisBuild / developers := List(
   tlGitHubDev("armanbilge", "Arman Bilge"),


### PR DESCRIPTION
The changes in https://github.com/typelevel/sbt-typelevel/pull/92 are good, but a little too breaking. For example the following `build.sbt` would stop working since the sonatype credentials are now expected to be provided on the step itself.

```scala
ThisBuild / githubWorkflowPublish := Seq(WorkflowStep.Sbt(List("tlRelease")))
```

There's no real urgency for this feature, so we can keep it on ice until v0.5.0 when the other breaking change will be making s01 the default host.