### PR TITLE
Make site plugin more robust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
       - name: Generate site
-        run: sbt '++${{ matrix.scala }}' tlSite
+        run: sbt '++${{ matrix.scala }}' docs/tlSite
 
       - name: Publish site
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'

--- a/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
+++ b/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
@@ -112,7 +112,10 @@ object TypelevelSitePlugin extends AutoPlugin {
       laika.parse.code.SyntaxHighlighting
     ),
     tlSiteGenerate := List(
-      WorkflowStep.Sbt(List("tlSite"), name = Some("Generate site"))
+      WorkflowStep.Sbt(
+        List(s"${thisProject.value.id}/${tlSite.key.toString}"),
+        name = Some("Generate site")
+      )
     ),
     tlSitePublish := List(
       WorkflowStep.Use(


### PR DESCRIPTION
Fixes https://github.com/typelevel/sbt-typelevel/issues/95.

It no longer assumes that the project id is `docs`. The input directory still defaults to `docs/`, but this is inherited from mdoc itself and thus can be changed in whatever the usual manner is.