### PR TITLE
Add "if relevant" versions of mima/publish commands

### DIFF
--- a/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
+++ b/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
@@ -71,7 +71,7 @@ object TypelevelKernelPlugin extends AutoPlugin {
           streams
             .value
             .log
-            .warn(s"skipping `${delegate.key.label}` in ${name.value}: $ver is not in $cross"))
+            .info(s"skipping `${delegate.key.label}` in ${name.value}: $ver is not in $cross"))
     }
 
 }

--- a/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
+++ b/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
@@ -66,12 +66,10 @@ object TypelevelKernelPlugin extends AutoPlugin {
 
       if (cross.contains(ver))
         Def.task(delegate.value)
-      else
-        Def.task(
-          streams
-            .value
-            .log
-            .info(s"skipping `${delegate.key.label}` in ${name.value}: $ver is not in $cross"))
+      else {
+        val msg = s"skipping `${delegate.key.label}` in ${name.value}: $ver is not in $cross"
+        Def.task(streams.value.log.info(msg))
+      }
     }
 
 }


### PR DESCRIPTION
This PR defines `tlPublishIfRelevant`, `tlPublishLocalIfRelevant`, and `tlMimaReportBinaryIssuesIfRelevant` and redefines `tlRelease` in terms of them. These are [inspired by sbt-spiewak](https://github.com/djspiewak/sbt-spiewak/blob/d689a5be2f3dba2c335b2be072870287fda701b8/core/src/main/scala/sbtspiewak/SpiewakPlugin.scala#L87).

These commands allow us to run e.g. `+tlMimaReportBinaryIssuesIfRelevant` even where there are holes in the `crossScalaVersions` for various subprojects. The if-relevant command checks if the current Scala version in `ThisBuild` belongs to the `crossScalaVersions` for that project, and if not, simply no-ops the command (with an info message logged).

I thought with Scala Native finally coming to Scala 3 we would finally be beyond these holes, but then I encountered this with spark in https://github.com/typelevel/frameless/pull/600.