### PR TITLE
Add ids to workflow steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,17 +60,21 @@ jobs:
         run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' 'project /' githubWorkflowCheck
 
       - name: Check headers and formatting
+        id: check-headers-fmt
         if: matrix.java == 'temurin@8'
         run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' headerCheckAll scalafmtCheckAll 'project /' scalafmtSbtCheck
 
       - name: Test
+        id: test
         run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' test
 
       - name: Check binary compatibility
+        id: mima
         if: matrix.java == 'temurin@8'
         run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' mimaReportBinaryIssues
 
       - name: Generate API documentation
+        id: doc
         if: matrix.java == 'temurin@8'
         run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' doc
 
@@ -135,10 +139,12 @@ jobs:
           rm targets.tar
 
       - name: Import signing key
+        id: import-key
         if: env.PGP_SECRET != '' && env.PGP_PASSPHRASE == ''
         run: echo $PGP_SECRET | base64 -d | gpg --import
 
       - name: Import signing key and strip passphrase
+        id: import-passphrased-key
         if: env.PGP_SECRET != '' && env.PGP_PASSPHRASE != ''
         run: |
           echo "$PGP_SECRET" | base64 -d > /tmp/signing-key.gpg
@@ -146,6 +152,7 @@ jobs:
           (echo "$PGP_PASSPHRASE"; echo; echo) | gpg --command-fd 0 --pinentry-mode loopback --change-passphrase $(gpg --list-secret-keys --with-colons 2> /dev/null | grep '^sec:' | cut --delimiter ':' --fields 5 | tail -n 1)
 
       - name: Publish
+        id: publish
         run: sbt '++${{ matrix.scala }}' tlRelease
 
   site:
@@ -182,9 +189,11 @@ jobs:
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
       - name: Generate site
+        id: site
         run: sbt '++${{ matrix.scala }}' docs/tlSite
 
       - name: Publish site
+        id: publish-site
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v3.8.0
         with:

--- a/ci-signing/src/main/scala/org/typelevel/sbt/TypelevelCiSigningPlugin.scala
+++ b/ci-signing/src/main/scala/org/typelevel/sbt/TypelevelCiSigningPlugin.scala
@@ -36,6 +36,7 @@ object TypelevelCiSigningPlugin extends AutoPlugin {
     githubWorkflowPublishPreamble := Seq(
       WorkflowStep.Run( // if your key is not passphrase-protected
         List("echo $PGP_SECRET | base64 -d | gpg --import"),
+        id = Some("import-key"),
         name = Some("Import signing key"),
         cond = Some("env.PGP_SECRET != '' && env.PGP_PASSPHRASE == ''")
       ),
@@ -45,6 +46,7 @@ object TypelevelCiSigningPlugin extends AutoPlugin {
           "echo \"$PGP_PASSPHRASE\" | gpg --pinentry-mode loopback --passphrase-fd 0 --import /tmp/signing-key.gpg",
           "(echo \"$PGP_PASSPHRASE\"; echo; echo) | gpg --command-fd 0 --pinentry-mode loopback --change-passphrase $(gpg --list-secret-keys --with-colons 2> /dev/null | grep '^sec:' | cut --delimiter ':' --fields 5 | tail -n 1)"
         ),
+        id = Some("import-passphrased-key"),
         name = Some("Import signing key and strip passphrase"),
         cond = Some("env.PGP_SECRET != '' && env.PGP_PASSPHRASE != ''")
       )

--- a/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
@@ -34,14 +34,20 @@ object TypelevelCiPlugin extends AutoPlugin {
   override def buildSettings = Seq(
     githubWorkflowPublishTargetBranches := Seq(),
     githubWorkflowBuild := Seq(
-      WorkflowStep.Sbt(List("test"), name = Some("Test")),
+      WorkflowStep.Sbt(
+        List("test"),
+        id = Some("test"),
+        name = Some("Test")
+      ),
       WorkflowStep.Sbt(
         List("mimaReportBinaryIssues"),
+        id = Some("mima"),
         name = Some("Check binary compatibility"),
         cond = Some(primaryJavaCond.value)
       ),
       WorkflowStep.Sbt(
         List("doc"),
+        id = Some("doc"),
         name = Some("Generate API documentation"),
         cond = Some(primaryJavaCond.value)
       )

--- a/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
+++ b/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
@@ -66,6 +66,7 @@ object TypelevelPlugin extends AutoPlugin {
     githubWorkflowBuild := {
       WorkflowStep.Sbt(
         List("headerCheckAll", "scalafmtCheckAll", "project /", "scalafmtSbtCheck"),
+        id = Some("check-headers-fmt"),
         name = Some("Check headers and formatting"),
         cond = Some(primaryJavaCond.value)
       ) +: githubWorkflowBuild.value

--- a/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
+++ b/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
@@ -114,6 +114,7 @@ object TypelevelSitePlugin extends AutoPlugin {
     tlSiteGenerate := List(
       WorkflowStep.Sbt(
         List(s"${thisProject.value.id}/${tlSite.key.toString}"),
+        id = Some("site"),
         name = Some("Generate site")
       )
     ),
@@ -130,6 +131,7 @@ object TypelevelSitePlugin extends AutoPlugin {
             .toString,
           "publish_branch" -> "gh-pages"
         ),
+        id = Some("publish-site"),
         name = Some("Publish site"),
         cond = {
           val predicate = tlSitePublishBranch

--- a/sonatype-ci-release/src/main/scala/org/typelevel/sbt/TypelevelSonatypeCiReleasePlugin.scala
+++ b/sonatype-ci-release/src/main/scala/org/typelevel/sbt/TypelevelSonatypeCiReleasePlugin.scala
@@ -59,7 +59,11 @@ object TypelevelSonatypeCiReleasePlugin extends AutoPlugin {
     },
     githubWorkflowTargetTags += "v*",
     githubWorkflowPublish := Seq(
-      WorkflowStep.Sbt(List("tlRelease"), name = Some("Publish"))
+      WorkflowStep.Sbt(
+        List("tlRelease"),
+        id = Some("publish"),
+        name = Some("Publish")
+      )
     )
   )
 }


### PR DESCRIPTION
This is part of the effort to provide a stable API. Some projects need to filter or otherwise identify steps in the workflow. But I'd also like to retain the freedom to change the exact commands that are used in these steps in patch releases (e.g., we may want to define and use a new command alias that keeps the step semantically equivalent but fixes/optimizes some issue).

I'll follow-up with some documentation explaining that the step ids will be stable, but the other contents of the step should not be relied upon.