### PR TITLE
Add `tlPrePrBotHook`

### DIFF
--- a/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
+++ b/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
@@ -20,7 +20,6 @@ import sbt._, Keys._
 import org.typelevel.sbt.gha.GenerativePlugin
 import org.typelevel.sbt.gha.GitHubActionsPlugin
 import de.heikoseeberger.sbtheader.HeaderPlugin
-import org.scalafmt.sbt.ScalafmtPlugin
 
 import scala.collection.immutable
 
@@ -31,17 +30,13 @@ object TypelevelPlugin extends AutoPlugin {
       TypelevelSettingsPlugin &&
       TypelevelCiReleasePlugin &&
       GitHubActionsPlugin &&
-      HeaderPlugin &&
-      ScalafmtPlugin
+      HeaderPlugin
 
   override def trigger = allRequirements
 
   object autoImport {
     lazy val tlFatalWarningsInCi = settingKey[Boolean](
       "Convert compiler warnings into errors under CI builds (default: true)")
-
-    lazy val tlPrePrBotHook =
-      taskKey[Unit]("A hook for bots like Scala Steward to run prePR commands")
   }
 
   import autoImport._
@@ -50,8 +45,6 @@ object TypelevelPlugin extends AutoPlugin {
   import TypelevelSonatypeCiReleasePlugin.autoImport._
   import GenerativePlugin.autoImport._
   import GitHubActionsPlugin.autoImport._
-  import HeaderPlugin.autoImport._
-  import ScalafmtPlugin.autoImport._
 
   override def globalSettings = Seq(
     tlFatalWarningsInCi := true
@@ -94,19 +87,20 @@ object TypelevelPlugin extends AutoPlugin {
         "reload"
       )
     )
+  ) ++ addCommandAlias(
+    "tlPrePrBotHook",
+    mkCommand(
+      List(
+        "githubWorkflowGenerate",
+        "headerCreateAll",
+        "scalafmtAll",
+        "scalafmtSbt"
+      )
+    )
   )
 
-  // immutable.Seq for bincompat
-  override def projectSettings = immutable.Seq(
-    tlPrePrBotHook := Def
-      .sequential(
-        githubWorkflowGenerate,
-        headerCreateAll,
-        scalafmtAll,
-        scalafmtSbt
-      )
-      .value
-  )
+  // override for bincompat
+  override def projectSettings = immutable.Seq.empty
 
   private val primaryJavaCond = Def.setting {
     val java = githubWorkflowJavaVersions.value.head

--- a/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
+++ b/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
@@ -94,16 +94,6 @@ object TypelevelPlugin extends AutoPlugin {
         "reload"
       )
     )
-  ) ++ addCommandAlias(
-    "tlPrePrBotHook",
-    mkCommand(
-      List(
-        "githubWorkflowGenerate",
-        "headerCreateAll",
-        "scalafmtAll",
-        "scalafmtSbt"
-      )
-    )
   )
 
   // immutable.Seq for bincompat

--- a/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
+++ b/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
@@ -20,6 +20,7 @@ import sbt._, Keys._
 import org.typelevel.sbt.gha.GenerativePlugin
 import org.typelevel.sbt.gha.GitHubActionsPlugin
 import de.heikoseeberger.sbtheader.HeaderPlugin
+import org.scalafmt.sbt.ScalafmtPlugin
 
 import scala.collection.immutable
 
@@ -30,13 +31,17 @@ object TypelevelPlugin extends AutoPlugin {
       TypelevelSettingsPlugin &&
       TypelevelCiReleasePlugin &&
       GitHubActionsPlugin &&
-      HeaderPlugin
+      HeaderPlugin &&
+      ScalafmtPlugin
 
   override def trigger = allRequirements
 
   object autoImport {
     lazy val tlFatalWarningsInCi = settingKey[Boolean](
       "Convert compiler warnings into errors under CI builds (default: true)")
+
+    lazy val tlPrePrBotHook =
+      taskKey[Unit]("A hook for bots like Scala Steward to run prePR commands")
   }
 
   import autoImport._
@@ -45,6 +50,8 @@ object TypelevelPlugin extends AutoPlugin {
   import TypelevelSonatypeCiReleasePlugin.autoImport._
   import GenerativePlugin.autoImport._
   import GitHubActionsPlugin.autoImport._
+  import HeaderPlugin.autoImport._
+  import ScalafmtPlugin.autoImport._
 
   override def globalSettings = Seq(
     tlFatalWarningsInCi := true
@@ -99,8 +106,17 @@ object TypelevelPlugin extends AutoPlugin {
     )
   )
 
-  // override for bincompat
-  override def projectSettings = immutable.Seq.empty
+  // immutable.Seq for bincompat
+  override def projectSettings = immutable.Seq(
+    tlPrePrBotHook := Def
+      .sequential(
+        githubWorkflowGenerate,
+        headerCreateAll,
+        scalafmtAll,
+        scalafmtSbt
+      )
+      .value
+  )
 
   private val primaryJavaCond = Def.setting {
     val java = githubWorkflowJavaVersions.value.head

--- a/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
+++ b/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
@@ -40,6 +40,7 @@ object TypelevelPlugin extends AutoPlugin {
   }
 
   import autoImport._
+  import TypelevelKernelPlugin.mkCommand
   import TypelevelSettingsPlugin.autoImport._
   import TypelevelSonatypeCiReleasePlugin.autoImport._
   import GenerativePlugin.autoImport._
@@ -72,7 +73,7 @@ object TypelevelPlugin extends AutoPlugin {
     }
   ) ++ addCommandAlias(
     "prePR",
-    TypelevelKernelPlugin.mkCommand(
+    mkCommand(
       List(
         "reload",
         "project /",
@@ -84,6 +85,16 @@ object TypelevelPlugin extends AutoPlugin {
         "set ThisBuild / tlFatalWarnings := tlFatalWarningsInCi.value",
         "Test / compile",
         "reload"
+      )
+    )
+  ) ++ addCommandAlias(
+    "tlPrePrHook",
+    mkCommand(
+      List(
+        "githubWorkflowGenerate",
+        "headerCreateAll",
+        "scalafmtAll",
+        "scalafmtSbt"
       )
     )
   )

--- a/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
+++ b/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
@@ -92,8 +92,8 @@ object TypelevelPlugin extends AutoPlugin {
     mkCommand(
       List(
         "githubWorkflowGenerate",
-        "headerCreateAll",
-        "scalafmtAll",
+        "+headerCreateAll",
+        "+scalafmtAll",
         "scalafmtSbt"
       )
     )

--- a/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
+++ b/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
@@ -88,7 +88,7 @@ object TypelevelPlugin extends AutoPlugin {
       )
     )
   ) ++ addCommandAlias(
-    "tlPrePrHook",
+    "tlPrePrBotHook",
     mkCommand(
       List(
         "githubWorkflowGenerate",


### PR DESCRIPTION
Another prePR-style alias, but this one skips the clean compile and is intended only for bots. Since sbt-typelevel absorbs so many plugins (sbt-gh-actions, sbt-scalafmt, etc.) this command will provide a unified way for scala-steward to run all the necessary post-upgrade steps. Will also be useful for https://github.com/typelevel/sbt-typelevel/issues/69 and any other ideas we come up with that require sbt-typelevel-managed files.