### PR TITLE
Integrate Unidoc with TypelevelSitePlugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,3 +191,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: mdocs/target/docs/site
           publish_branch: gh-pages
+          keep_files: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,7 @@ jobs:
         run: sbt '++${{ matrix.scala }}' docs/tlSite
 
       - name: Publish site
-        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
         uses: peaceiris/actions-gh-pages@v3.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,5 +190,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: mdocs/target/docs/site
-          publish_branch: gh-pages
           keep_files: true

--- a/build.sbt
+++ b/build.sbt
@@ -146,7 +146,7 @@ lazy val site = project
   .settings(
     name := "sbt-typelevel-site"
   )
-  .dependsOn(kernel, githubActions, noPublish)
+  .dependsOn(kernel, github, githubActions, noPublish)
 
 lazy val docs = project
   .in(file("mdocs"))

--- a/build.sbt
+++ b/build.sbt
@@ -151,4 +151,10 @@ lazy val site = project
 lazy val docs = project
   .in(file("mdocs"))
   .enablePlugins(TypelevelSitePlugin)
+  .enablePlugins(ScalaUnidocPlugin)
   .settings(laikaConfig ~= { _.withRawContent })
+  .settings(
+    laikaIncludeAPI := true,
+    autoAPIMappings := true,
+    laikaGenerateAPI / mappings := (site/Compile / packageDoc / mappings).value
+  )

--- a/build.sbt
+++ b/build.sbt
@@ -152,9 +152,7 @@ lazy val docs = project
   .in(file("mdocs"))
   .enablePlugins(TypelevelSitePlugin)
   .enablePlugins(ScalaUnidocPlugin)
-  .settings(laikaConfig ~= { _.withRawContent })
   .settings(
-    laikaIncludeAPI := true,
-    autoAPIMappings := true,
-    laikaGenerateAPI / mappings := (site/Compile / packageDoc / mappings).value
+    tlSiteApiUri := Some(uri("api/org/typelevel/sbt/")),
+    laikaConfig ~= { _.withRawContent }
   )

--- a/site/build.sbt
+++ b/site/build.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.24")
 addSbtPlugin("org.planet42" % "laika-sbt" % "0.18.1")
+addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")

--- a/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
+++ b/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
@@ -38,6 +38,8 @@ object TypelevelSitePlugin extends AutoPlugin {
       "0.4.4")
     lazy val tlSiteApiUrl = settingKey[Option[URL]]("URL to the API docs")
     lazy val tlSiteApiUri = settingKey[Option[URI]]("URI to the API docs")
+    lazy val tlSiteKeepFiles =
+      settingKey[Boolean]("Whether to keep existing files when deploying site (default: true)")
     lazy val tlSiteGenerate = settingKey[Seq[WorkflowStep]](
       "A sequence of workflow steps which generates the site (default: [Sbt(List(\"tlSite\"))])")
     lazy val tlSitePublish = settingKey[Seq[WorkflowStep]](
@@ -57,6 +59,7 @@ object TypelevelSitePlugin extends AutoPlugin {
     tlSitePublishBranch := Some("main"),
     tlSiteApiUri := None,
     tlSiteApiUrl := None: @nowarn,
+    tlSiteKeepFiles := true,
     homepage := {
       gitHubUserRepo.value.map {
         case ("typelevel", repo) => url(s"https://typelevel.org/$repo")
@@ -145,7 +148,8 @@ object TypelevelSitePlugin extends AutoPlugin {
             .toAbsolutePath
             .relativize(((Laika / target).value / "site").toPath)
             .toString,
-          "publish_branch" -> "gh-pages"
+          "publish_branch" -> "gh-pages",
+          "keep_files" -> tlSiteKeepFiles.value.toString
         ),
         name = Some("Publish site"),
         cond = {

--- a/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
+++ b/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
@@ -148,7 +148,6 @@ object TypelevelSitePlugin extends AutoPlugin {
             .toAbsolutePath
             .relativize(((Laika / target).value / "site").toPath)
             .toString,
-          "publish_branch" -> "gh-pages",
           "keep_files" -> tlSiteKeepFiles.value.toString
         ),
         name = Some("Publish site"),

--- a/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
+++ b/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
@@ -33,7 +33,9 @@ object TypelevelSitePlugin extends AutoPlugin {
 
   object autoImport {
     lazy val tlSiteHeliumConfig = settingKey[Helium]("The Helium configuration")
+    @deprecated("Use tlSiteApiUri", "0.4.4")
     lazy val tlSiteApiUrl = settingKey[Option[URL]]("URL to the API docs")
+    lazy val tlSiteApiUri = settingKey[Option[URI]]("URI to the API docs")
     lazy val tlSiteGenerate = settingKey[Seq[WorkflowStep]](
       "A sequence of workflow steps which generates the site (default: [Sbt(List(\"tlSite\"))])")
     lazy val tlSitePublish = settingKey[Seq[WorkflowStep]](
@@ -49,7 +51,8 @@ object TypelevelSitePlugin extends AutoPlugin {
 
   override def buildSettings = Seq(
     tlSitePublishBranch := Some("main"),
-    tlSiteApiUrl := None
+    tlSiteApiUri := None,
+    tlSiteApiUrl := None: @nowarn
   )
 
   override def projectSettings = Seq(
@@ -91,13 +94,17 @@ object TypelevelSitePlugin extends AutoPlugin {
             "https://typelevel.org",
             Image.external(s"data:image/svg+xml;base64,$getSvgLogo")
           ),
-          navLinks = tlSiteApiUrl.value.toList.map { url =>
-            IconLink.external(
-              url.toString,
-              HeliumIcon.api,
-              options = Styles("svg-link")
-            )
-          } ++ List(
+          navLinks = tlSiteApiUri
+            .value
+            .orElse(tlSiteApiUrl.value.map(_.toURI): @nowarn)
+            .toList
+            .map { url =>
+              IconLink.external(
+                url.toString,
+                HeliumIcon.api,
+                options = Styles("svg-link")
+              )
+            } ++ List(
             IconLink.external(
               scmInfo.value.fold("https://github.com/typelevel")(_.browseUrl.toString),
               HeliumIcon.github,

--- a/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
+++ b/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
@@ -33,7 +33,9 @@ object TypelevelSitePlugin extends AutoPlugin {
 
   object autoImport {
     lazy val tlSiteHeliumConfig = settingKey[Helium]("The Helium configuration")
-    @deprecated("Use tlSiteApiUri", "0.4.4")
+    @deprecated(
+      "Use tlSiteApiUri or enable the ScalaUnidocPlugin on your docs project",
+      "0.4.4")
     lazy val tlSiteApiUrl = settingKey[Option[URL]]("URL to the API docs")
     lazy val tlSiteApiUri = settingKey[Option[URI]]("URI to the API docs")
     lazy val tlSiteGenerate = settingKey[Seq[WorkflowStep]](

--- a/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
+++ b/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
@@ -62,8 +62,8 @@ object TypelevelSitePlugin extends AutoPlugin {
     tlSiteKeepFiles := true,
     homepage := {
       gitHubUserRepo.value.map {
-        case ("typelevel", repo) => url(s"https://typelevel.org/$repo")
-        case (user, repo) => url(s"https://$user.github.io/$repo")
+        case ("typelevel", repo) => url(s"https://typelevel.org/$repo/")
+        case (user, repo) => url(s"https://$user.github.io/$repo/")
       }
     }
   )

--- a/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
+++ b/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
@@ -48,13 +48,21 @@ object TypelevelSitePlugin extends AutoPlugin {
   }
 
   import autoImport._
+  import TypelevelGitHubPlugin._
 
-  override def requires = MdocPlugin && LaikaPlugin && GenerativePlugin && NoPublishPlugin
+  override def requires =
+    MdocPlugin && LaikaPlugin && TypelevelGitHubPlugin && GenerativePlugin && NoPublishPlugin
 
   override def buildSettings = Seq(
     tlSitePublishBranch := Some("main"),
     tlSiteApiUri := None,
-    tlSiteApiUrl := None: @nowarn
+    tlSiteApiUrl := None: @nowarn,
+    homepage := {
+      gitHubUserRepo.value.map {
+        case ("typelevel", repo) => url(s"https://typelevel.org/$repo")
+        case (user, repo) => url(s"https://$user.github.io/$repo")
+      }
+    }
   )
 
   override def projectSettings = Seq(

--- a/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
+++ b/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
@@ -79,7 +79,7 @@ object TypelevelSitePlugin extends AutoPlugin {
     laikaTheme := tlSiteHeliumConfig.value.build,
     mdocVariables ++= Map(
       "VERSION" -> GitHelper
-        .previousReleases()
+        .previousReleases(fromHead = true)
         .filterNot(_.isPrerelease)
         .headOption
         .fold(version.value)(_.toString),

--- a/site/src/main/scala/org/typelevel/sbt/TypelevelUnidocPlugin.scala
+++ b/site/src/main/scala/org/typelevel/sbt/TypelevelUnidocPlugin.scala
@@ -19,6 +19,7 @@ package org.typelevel.sbt
 import sbt._, Keys._
 import sbtunidoc.ScalaUnidocPlugin
 import laika.sbt.LaikaPlugin
+import org.typelevel.sbt.kernel.V
 
 object TypelevelUnidocPlugin extends AutoPlugin {
 
@@ -43,7 +44,11 @@ object TypelevelUnidocPlugin extends AutoPlugin {
   )
 
   override def projectSettings = Seq(
-    laikaIncludeAPI := true,
+    laikaIncludeAPI := {
+      // include the API docs, only if this is not a snapshot nor a pre-release
+      // so long as tlSiteKeepFiles is true, it won't delete existing API docs
+      !isSnapshot.value && V.unapply(version.value).exists(!_.isPrerelease)
+    },
     laikaGenerateAPI / mappings := (ScalaUnidoc / packageDoc / mappings).value
   )
 

--- a/site/src/main/scala/org/typelevel/sbt/TypelevelUnidocPlugin.scala
+++ b/site/src/main/scala/org/typelevel/sbt/TypelevelUnidocPlugin.scala
@@ -30,10 +30,20 @@ object TypelevelUnidocPlugin extends AutoPlugin {
   import LaikaPlugin.autoImport._
   import ScalaUnidocPlugin.autoImport._
 
-  override def projectSettings = Seq(
+  override def buildSettings = Seq(
     tlSiteApiUri := Some(uri("api/")),
+    apiURL := {
+      tlSiteApiUri.value.flatMap { api =>
+        if (api.isAbsolute())
+          Some(api.toURL)
+        else // resolve the api relative to the homepage
+          homepage.value.map(_.toURI.resolve(api).toURL)
+      }
+    }
+  )
+
+  override def projectSettings = Seq(
     laikaIncludeAPI := true,
-    autoAPIMappings := true,
     laikaGenerateAPI / mappings := (ScalaUnidoc / packageDoc / mappings).value
   )
 

--- a/site/src/main/scala/org/typelevel/sbt/TypelevelUnidocPlugin.scala
+++ b/site/src/main/scala/org/typelevel/sbt/TypelevelUnidocPlugin.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.sbt
+
+import sbt._, Keys._
+import sbtunidoc.ScalaUnidocPlugin
+import laika.sbt.LaikaPlugin
+
+object TypelevelUnidocPlugin extends AutoPlugin {
+
+  override def requires = TypelevelSitePlugin && ScalaUnidocPlugin
+
+  override def trigger = allRequirements
+
+  import TypelevelSitePlugin.autoImport._
+  import LaikaPlugin.autoImport._
+  import ScalaUnidocPlugin.autoImport._
+
+  override def projectSettings = Seq(
+    tlSiteApiUri := Some(uri("api/")),
+    laikaIncludeAPI := true,
+    autoAPIMappings := true,
+    laikaGenerateAPI / mappings := (ScalaUnidoc / packageDoc / mappings).value
+  )
+
+}

--- a/site/src/main/scala/org/typelevel/sbt/TypelevelUnidocPlugin.scala
+++ b/site/src/main/scala/org/typelevel/sbt/TypelevelUnidocPlugin.scala
@@ -35,7 +35,7 @@ object TypelevelUnidocPlugin extends AutoPlugin {
     tlSiteApiUri := Some(uri("api/")),
     apiURL := {
       tlSiteApiUri.value.flatMap { api =>
-        if (api.isAbsolute())
+        if (api.isAbsolute)
           Some(api.toURL)
         else // resolve the api relative to the homepage
           homepage.value.map(_.toURI.resolve(api).toURL)

--- a/site/src/main/scala/org/typelevel/sbt/TypelevelUnidocPlugin.scala
+++ b/site/src/main/scala/org/typelevel/sbt/TypelevelUnidocPlugin.scala
@@ -20,6 +20,7 @@ import sbt._, Keys._
 import sbtunidoc.ScalaUnidocPlugin
 import laika.sbt.LaikaPlugin
 import org.typelevel.sbt.kernel.V
+import org.typelevel.sbt.gha.GitHubActionsKeys._
 
 object TypelevelUnidocPlugin extends AutoPlugin {
 
@@ -47,7 +48,10 @@ object TypelevelUnidocPlugin extends AutoPlugin {
     laikaIncludeAPI := {
       // include the API docs, only if this is not a snapshot nor a pre-release
       // so long as tlSiteKeepFiles is true, it won't delete existing API docs
-      !isSnapshot.value && V.unapply(version.value).exists(!_.isPrerelease)
+      val isRelease = !isSnapshot.value && V.unapply(version.value).exists(!_.isPrerelease)
+
+      // If we're not in CI, we'll include them anyway
+      !githubIsWorkflowBuild.value || isRelease
     },
     laikaGenerateAPI / mappings := (ScalaUnidoc / packageDoc / mappings).value
   )


### PR DESCRIPTION
Closes https://github.com/typelevel/sbt-typelevel/issues/108.

- adds a `TypelevelUnidocPlugin` that kicks-in if the `ScalaUnidocPlugin` is enabled on the docs project
- API docs are copied into the Laika site, but only if this is a release tag (not a snapshot nor a pre-release tag)
- deploying the site now keeps existing files, so API docs persist even if they are not updated
- `homepage` and `apiURL` settings are populated automatically

One bit of trickiness is that even with this plugin enabled, your API docs URL will 404 until you do a tag release. This makes sense—in theory, you'd have to go back to the tag for the last stable release and deploy from there.

A temporary workaround is to either manually upload docs to the appropriately directory or set `tlSiteApiUri` to e.g. a javadoc.io url. Or just tag a release :)
