### PR TITLE
Integrate with `skip`

### DIFF
--- a/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
+++ b/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
@@ -48,7 +48,7 @@ object TypelevelKernelPlugin extends AutoPlugin {
     skip := {
       skip.value || {
         val cross = crossScalaVersions.value
-        val ver = (ThisBuild / scalaVersion).value
+        val ver = (LocalRootProject / scalaVersion).value
         !cross.contains(ver)
       }
     }

--- a/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
+++ b/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
@@ -44,6 +44,16 @@ object TypelevelKernelPlugin extends AutoPlugin {
   override def buildSettings =
     addCommandAlias("tlReleaseLocal", mkCommand(List("reload", "project /", "+publishLocal")))
 
+  override def projectSettings = Seq(
+    skip := {
+      skip.value || {
+        val cross = crossScalaVersions.value
+        val ver = (ThisBuild / scalaVersion).value
+        !cross.contains(ver)
+      }
+    }
+  )
+
   private[sbt] def mkCommand(commands: List[String]): String = commands.mkString("; ", "; ", "")
 
 }

--- a/mima/src/main/scala/org/typelevel/sbt/TypelevelMimaPlugin.scala
+++ b/mima/src/main/scala/org/typelevel/sbt/TypelevelMimaPlugin.scala
@@ -41,6 +41,11 @@ object TypelevelMimaPlugin extends AutoPlugin {
   )
 
   override def projectSettings = Seq[Setting[_]](
+    mimaReportBinaryIssues := {
+      if ((mimaReportBinaryIssues / skip).value)
+        ()
+      else mimaReportBinaryIssues.value
+    },
     mimaPreviousArtifacts := {
       require(
         versionScheme.value.contains("early-semver"),


### PR DESCRIPTION
A (better) alternative to https://github.com/typelevel/sbt-typelevel/pull/101. This was a good lead.

1. Automatically sets `skip := true` if `crossScalaVersions` for a project does not contain the current `scalaVersion`.
2. Makes `mimaReportBinaryIssues` skip-aware.

I'm going to a snapshot this branch to test it out in frameless. Update: seems to work.