### PR TITLE
Read default scala version from `ThisBuild`

### DIFF
--- a/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
+++ b/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
@@ -57,10 +57,10 @@ object TypelevelPlugin extends AutoPlugin {
     tlCiReleaseBranches := Seq("main"),
     Def.derive(tlFatalWarnings := (tlFatalWarningsInCi.value && githubIsWorkflowBuild.value)),
     githubWorkflowBuildMatrixExclusions ++= {
+      val defaultScala = (ThisBuild / scalaVersion).value
       for {
-        // default scala is last in the list, default java first
-        scala <- githubWorkflowScalaVersions.value.init
-        java <- githubWorkflowJavaVersions.value.tail
+        scala <- githubWorkflowScalaVersions.value.filterNot(_ == defaultScala)
+        java <- githubWorkflowJavaVersions.value.tail // default java is head
       } yield MatrixExclude(Map("scala" -> scala, "java" -> java.render))
     },
     githubWorkflowBuild := {

--- a/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
+++ b/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
@@ -145,7 +145,7 @@ object TypelevelSitePlugin extends AutoPlugin {
       WorkflowJob(
         "site",
         "Generate Site",
-        scalas = List(crossScalaVersions.value.last),
+        scalas = List((ThisBuild / scalaVersion).value),
         javas = List(githubWorkflowJavaVersions.value.head),
         steps =
           githubWorkflowJobSetup.value.toList ++ tlSiteGenerate.value ++ tlSitePublish.value


### PR DESCRIPTION
@danicheg reminded me in https://github.com/typelevel/mouse/pull/305 how confusing it is to use the last Scala as the default. Turns out that `ThisBuild / scalaVersion` is fine, I thought it would generate different workflows depending on `++` but it seems not.