### PR TITLE
Don't set version scheme in settings plugin

### DIFF
--- a/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
+++ b/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
@@ -40,7 +40,6 @@ object TypelevelSettingsPlugin extends AutoPlugin {
   )
 
   override def projectSettings = Seq(
-    versionScheme := Some("early-semver"),
     pomIncludeRepository := { _ => false },
     libraryDependencies ++= {
       if (tlIsScala3.value)


### PR DESCRIPTION
This is scope creep: the settings plugin is focused on scalac and javac flags and should be usable in non-libraries.

The version scheme is already set in the versioning plugin anyway, where it makes sense.

Breaking enough that it goes into 0.5.