### PR TITLE
Don't generate artifact upload steps if not publishing

### DIFF
--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativePlugin.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativePlugin.scala
@@ -565,7 +565,10 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}
     githubWorkflowPREventTypes := PREventType.Defaults,
     githubWorkflowArtifactDownloadExtraKeys := Set.empty,
     githubWorkflowGeneratedUploadSteps := {
-      if (githubWorkflowArtifactUpload.value) {
+      val generate =
+        githubWorkflowArtifactUpload.value &&
+          githubWorkflowPublishTargetBranches.value.nonEmpty
+      if (generate) {
         val sanitized = pathStrs.value map { str =>
           if (str.indexOf(' ') >= 0) // TODO be less naive
             s"'$str'"


### PR DESCRIPTION
This is the same condition used to determine whether to generate the publish job at all.