### PR TITLE
Prereleases come before releases

### DIFF
--- a/kernel/src/main/scala/org/typelevel/sbt/kernel/V.scala
+++ b/kernel/src/main/scala/org/typelevel/sbt/kernel/V.scala
@@ -50,8 +50,8 @@ private[sbt] final case class V(
         if (z != 0) return z
         (this.prerelease, that.prerelease) match {
           case (None, None) => 0
-          case (Some(_), None) => 1
-          case (None, Some(_)) => -1
+          case (Some(_), None) => -1
+          case (None, Some(_)) => 1
           case (Some(thisPrerelease), Some(thatPrerelease)) =>
             // TODO not great, but not everyone uses Ms and RCs
             thisPrerelease.compare(thatPrerelease)


### PR DESCRIPTION
On http4s-fabric, there are three tags:
* v1.0.0-M30
* v1.0.0-M30.1 (trying to publish)
* v1.0.0 (unpublished)

M30.1 is failing trying to MiMa the non-existent 1.0.0, because it thinks 1.0.0-M30.1 > 1.0.0.  It should be filtered: a prerelease comes before the corresponding final release.

See https://github.com/http4s/http4s-fabric/issues/1