### PR TITLE
`fastOptJS` -> `fastLinkJS`

### DIFF
--- a/ci/src/main/scala/org/typelevel/sbt/CrossRootProject.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/CrossRootProject.scala
@@ -149,8 +149,8 @@ object TypelevelCiJSPlugin extends AutoPlugin {
       steps.flatMap {
         case testStep @ WorkflowStep.Sbt(List("test"), _, _, _, _, _) =>
           val fastOptStep = WorkflowStep.Sbt(
-            List("Test/fastOptJS"),
-            name = Some("fastOptJS"),
+            List("Test/fastLinkJS"),
+            name = Some("fastLinkJS"),
             cond = Some("matrix.project == 'rootJS'")
           )
           List(fastOptStep, testStep)


### PR DESCRIPTION
I've always thought these are aliases so not gonna lie, I chose the one that sounded cooler 🤦 

FTR `fastOptJS` is legacy and doesn't support some of the newer features that `fastLinkJS` does.