### PR TITLE
Fix Apache 2.0 license url

### DIFF
--- a/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
+++ b/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
@@ -54,7 +54,7 @@ object TypelevelPlugin extends AutoPlugin {
     organization := "org.typelevel",
     organizationName := "Typelevel",
     startYear := Some(java.time.YearMonth.now().getYear()),
-    licenses += "Apache-2.0" -> url("http://www.apache.org/licenses/"),
+    licenses += "Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0.txt"),
     tlCiReleaseBranches := Seq("main"),
     Def.derive(tlFatalWarnings := (tlFatalWarningsInCi.value && githubIsWorkflowBuild.value)),
     githubWorkflowBuildMatrixExclusions ++= {


### PR DESCRIPTION
A shortcut `License.Apache2` was added in https://github.com/sbt/librarymanagement/pull/395 but I'm hesitant to unnecessarily rely on new sbt features for builds stuck on old versions for whatever reason.