### PR TITLE
Use unique names for publish resolvers

### DIFF
--- a/sonatype/src/main/scala/org/typelevel/sbt/TypelevelSonatypePlugin.scala
+++ b/sonatype/src/main/scala/org/typelevel/sbt/TypelevelSonatypePlugin.scala
@@ -60,6 +60,31 @@ object TypelevelSonatypePlugin extends AutoPlugin {
       else
         "s01.oss.sonatype.org"
     },
+    sonatypeSnapshotResolver := {
+      MavenRepository(
+        s"${sonatypeCredentialHost.value.replace('.', '-')}-snapshots",
+        s"https://${sonatypeCredentialHost.value}/content/repositories/snapshots"
+      )
+    },
+    sonatypeStagingResolver := {
+      MavenRepository(
+        s"${sonatypeCredentialHost.value.replace('.', '-')}-staging",
+        s"https://${sonatypeCredentialHost.value}/service/local/staging/deploy/maven2"
+      )
+    },
+    sonatypeDefaultResolver := {
+      val profileM = sonatypeTargetRepositoryProfile.?.value
+      val repository = sonatypeRepository.value
+      val staged = profileM.map { stagingRepoProfile =>
+        "releases" at s"${repository}/${stagingRepoProfile.deployPath}"
+        s"${sonatypeCredentialHost.value.replace('.', '-')}-releases" at s"${repository}/${stagingRepoProfile.deployPath}"
+      }
+      staged.getOrElse(if (version.value.endsWith("-SNAPSHOT")) {
+        sonatypeSnapshotResolver.value
+      } else {
+        sonatypeStagingResolver.value
+      })
+    },
     apiURL := {
       val javadocio = CrossVersion(
         crossVersion.value,


### PR DESCRIPTION
Temporarily inlines the fix from https://github.com/xerial/sbt-sonatype/pull/279 with an unfortunate amount of duplication.