### PR TITLE
Use `scalaJSLinkerResult` for linking step

### DIFF
--- a/ci/src/main/scala/org/typelevel/sbt/CrossRootProject.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/CrossRootProject.scala
@@ -149,8 +149,8 @@ object TypelevelCiJSPlugin extends AutoPlugin {
       steps.flatMap {
         case testStep @ WorkflowStep.Sbt(List("test"), _, _, _, _, _) =>
           val fastOptStep = WorkflowStep.Sbt(
-            List("Test/fastLinkJS"),
-            name = Some("fastLinkJS"),
+            List("Test/scalaJSLinkerResult"),
+            name = Some("scalaJSLink"),
             cond = Some("matrix.project == 'rootJS'")
           )
           List(fastOptStep, testStep)


### PR DESCRIPTION
This one respects the `scalaJSStage` setting and delegates to `fastLinkJS` or `fullLinkJS` as appropriate.