### PR TITLE
Don't `skip` the `update` task

### DIFF
--- a/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
+++ b/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
@@ -56,7 +56,7 @@ object TypelevelKernelPlugin extends AutoPlugin {
       }
     },
     update / skip := {
-      if (tlSkipIrrelevantScalas)
+      if (tlSkipIrrelevantScalas.value)
         false // sadly, skipping update is effectively a fatal error
       else
         (update / skip).value

--- a/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
+++ b/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
@@ -54,6 +54,12 @@ object TypelevelKernelPlugin extends AutoPlugin {
         val ver = (LocalRootProject / scalaVersion).value
         tlSkipIrrelevantScalas.value && !cross.contains(ver)
       }
+    },
+    update / skip := {
+      if (tlSkipIrrelevantScalas)
+        false // sadly, skipping update is effectively a fatal error
+      else
+        (update / skip).value
     }
   )
 


### PR DESCRIPTION
Fixes https://github.com/typelevel/sbt-typelevel/issues/140. (hopefully :grimacing:)

Unfortunately `update / skip` is (almost always) a fatal error, and according to https://github.com/sbt/sbt/issues/5056 that is unlikely to change. So, we don't skip it.