### PR TITLE
More responsible skipping

### DIFF
--- a/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
+++ b/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
@@ -48,15 +48,22 @@ object TypelevelKernelPlugin extends AutoPlugin {
       addCommandAlias("tlReleaseLocal", mkCommand(List("reload", "project /", "+publishLocal")))
 
   override def projectSettings = Seq(
-    skip := {
-      skip.value || {
+    skipIfIrrelevant(compile),
+    skipIfIrrelevant(test),
+    skipIfIrrelevant(publishLocal),
+    skipIfIrrelevant(publish)
+  )
+
+  private[sbt] def mkCommand(commands: List[String]): String = commands.mkString("; ", "; ", "")
+
+  private[sbt] def skipIfIrrelevant[T](task: TaskKey[T]) = {
+    task / skip := {
+      (task / skip).value || {
         val cross = crossScalaVersions.value
         val ver = (LocalRootProject / scalaVersion).value
         tlSkipIrrelevantScalas.value && !cross.contains(ver)
       }
     }
-  )
-
-  private[sbt] def mkCommand(commands: List[String]): String = commands.mkString("; ", "; ", "")
+  }
 
 }

--- a/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
+++ b/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
@@ -49,7 +49,7 @@ object TypelevelKernelPlugin extends AutoPlugin {
 
   override def projectSettings = Seq(
     (Test / test) := {
-      if ((Test / test / skip).value)
+      if (tlSkipIrrelevantScalas.value && (Test / test / skip).value)
         ()
       else (Test / test).value
     },

--- a/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
+++ b/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
@@ -48,6 +48,13 @@ object TypelevelKernelPlugin extends AutoPlugin {
       addCommandAlias("tlReleaseLocal", mkCommand(List("reload", "project /", "+publishLocal")))
 
   override def projectSettings = Seq(
+    (Test / test) := {
+      if ((Test / test / skip).value)
+        ()
+      else (Test / test).value
+    },
+    skipIfIrrelevant(compile),
+    skipIfIrrelevant(test),
     skipIfIrrelevant(publishLocal),
     skipIfIrrelevant(publish)
   )

--- a/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
+++ b/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
@@ -27,7 +27,7 @@ object TypelevelKernelPlugin extends AutoPlugin {
   object autoImport {
     lazy val tlIsScala3 = settingKey[Boolean]("True if building with Scala 3")
     lazy val tlSkipIrrelevantScalas = settingKey[Boolean](
-      "Sets skip := true for a project if the current scalaVersion is not in that project's crossScalaVersions (default: false)")
+      "Sets skip := true for compile/test/publish/etc. tasks on a project if the current scalaVersion is not in that project's crossScalaVersions (default: false)")
 
     def tlReplaceCommandAlias(name: String, contents: String): Seq[Setting[State => State]] =
       Seq(GlobalScope / onLoad ~= { (f: State => State) =>

--- a/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
+++ b/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
@@ -48,6 +48,11 @@ object TypelevelKernelPlugin extends AutoPlugin {
       addCommandAlias("tlReleaseLocal", mkCommand(List("reload", "project /", "+publishLocal")))
 
   override def projectSettings = Seq(
+    test := {
+      if ((test / skip).value)
+        ()
+      else test.value
+    },
     skipIfIrrelevant(compile),
     skipIfIrrelevant(test),
     skipIfIrrelevant(publishLocal),

--- a/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
+++ b/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
@@ -48,13 +48,6 @@ object TypelevelKernelPlugin extends AutoPlugin {
       addCommandAlias("tlReleaseLocal", mkCommand(List("reload", "project /", "+publishLocal")))
 
   override def projectSettings = Seq(
-    (Test / test) := {
-      if ((Test / test / skip).value)
-        ()
-      else (Test / test).value
-    },
-    skipIfIrrelevant(compile),
-    skipIfIrrelevant(test),
     skipIfIrrelevant(publishLocal),
     skipIfIrrelevant(publish)
   )

--- a/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
+++ b/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
@@ -61,7 +61,7 @@ object TypelevelKernelPlugin extends AutoPlugin {
       (task / skip).value || {
         val cross = crossScalaVersions.value
         val ver = (LocalRootProject / scalaVersion).value
-        tlSkipIrrelevantScalas.value && !cross.contains(ver)
+        (task / tlSkipIrrelevantScalas).value && !cross.contains(ver)
       }
     }
   }

--- a/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
+++ b/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
@@ -48,10 +48,10 @@ object TypelevelKernelPlugin extends AutoPlugin {
       addCommandAlias("tlReleaseLocal", mkCommand(List("reload", "project /", "+publishLocal")))
 
   override def projectSettings = Seq(
-    test := {
-      if ((test / skip).value)
+    (Test / test) := {
+      if ((Test / test / skip).value)
         ()
-      else test.value
+      else (Test / test).value
     },
     skipIfIrrelevant(compile),
     skipIfIrrelevant(test),

--- a/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
+++ b/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
@@ -27,7 +27,7 @@ object TypelevelKernelPlugin extends AutoPlugin {
   object autoImport {
     lazy val tlIsScala3 = settingKey[Boolean]("True if building with Scala 3")
     lazy val tlSkipIrrelevantScalas = settingKey[Boolean](
-      "Sets skip := true for a project if the current scalaVersion is not in that project's crossScalaVersions (default: true)")
+      "Sets skip := true for a project if the current scalaVersion is not in that project's crossScalaVersions (default: false)")
 
     def tlReplaceCommandAlias(name: String, contents: String): Seq[Setting[State => State]] =
       Seq(GlobalScope / onLoad ~= { (f: State => State) =>

--- a/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
+++ b/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
@@ -61,7 +61,11 @@ object TypelevelKernelPlugin extends AutoPlugin {
 
   private[sbt] def mkCommand(commands: List[String]): String = commands.mkString("; ", "; ", "")
 
-  private[sbt] def skipIfIrrelevant[T](task: TaskKey[T]) = {
+  /**
+   * A setting that will make a task respect the `tlSkipIrrelevantScalas` setting. Note that the
+   * task itself must respect `skip` for this to take effect.
+   */
+  def skipIfIrrelevant[T](task: TaskKey[T]) = {
     task / skip := {
       (task / skip).value || {
         val cross = crossScalaVersions.value

--- a/mima/src/main/scala/org/typelevel/sbt/TypelevelMimaPlugin.scala
+++ b/mima/src/main/scala/org/typelevel/sbt/TypelevelMimaPlugin.scala
@@ -35,6 +35,7 @@ object TypelevelMimaPlugin extends AutoPlugin {
   }
 
   import autoImport._
+  import TypelevelKernelPlugin.autoImport._
   import TypelevelKernelPlugin.skipIfIrrelevant
 
   override def buildSettings = Seq(
@@ -43,7 +44,7 @@ object TypelevelMimaPlugin extends AutoPlugin {
 
   override def projectSettings = Seq[Setting[_]](
     mimaReportBinaryIssues := {
-      if ((mimaReportBinaryIssues / skip).value)
+      if (tlSkipIrrelevantScalas.value && (mimaReportBinaryIssues / skip).value)
         ()
       else mimaReportBinaryIssues.value
     },

--- a/mima/src/main/scala/org/typelevel/sbt/TypelevelMimaPlugin.scala
+++ b/mima/src/main/scala/org/typelevel/sbt/TypelevelMimaPlugin.scala
@@ -35,6 +35,7 @@ object TypelevelMimaPlugin extends AutoPlugin {
   }
 
   import autoImport._
+  import TypelevelKernelPlugin.skipIfIrrelevant
 
   override def buildSettings = Seq(
     tlVersionIntroduced := Map.empty
@@ -46,6 +47,7 @@ object TypelevelMimaPlugin extends AutoPlugin {
         ()
       else mimaReportBinaryIssues.value
     },
+    skipIfIrrelevant(mimaReportBinaryIssues),
     mimaPreviousArtifacts := {
       require(
         versionScheme.value.contains("early-semver"),


### PR DESCRIPTION
Fixes #140, this time for real.

Two changes:
1. Don't set `skip := true` for a whole project. Instead set it task-by-task, for tasks where skipping is known to be "safe".
2. Make this feature opt-in. More builds broke than builds that actually need this. It's a good default in theory, but in practice there are too many complex interactions that makes stuff break in confusing ways.