### PR TITLE
Use typelevel jdk index for managing Java

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,21 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Download Java (temurin@8)
+        id: download-java-temurin-8
+        if: matrix.java == 'temurin@8'
+        uses: typelevel/download-java@v1
+        with:
+          distribution: temurin
+          java-version: 8
+
       - name: Setup Java (temurin@8)
         if: matrix.java == 'temurin@8'
         uses: actions/setup-java@v2
         with:
-          distribution: temurin
+          distribution: jdkfile
           java-version: 8
+          jdkFile: ${{ steps.download-java-temurin-8.outputs.jdkFile }}
 
       - name: Cache sbt
         uses: actions/cache@v2
@@ -106,12 +115,21 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Download Java (temurin@8)
+        id: download-java-temurin-8
+        if: matrix.java == 'temurin@8'
+        uses: typelevel/download-java@v1
+        with:
+          distribution: temurin
+          java-version: 8
+
       - name: Setup Java (temurin@8)
         if: matrix.java == 'temurin@8'
         uses: actions/setup-java@v2
         with:
-          distribution: temurin
+          distribution: jdkfile
           java-version: 8
+          jdkFile: ${{ steps.download-java-temurin-8.outputs.jdkFile }}
 
       - name: Cache sbt
         uses: actions/cache@v2
@@ -163,12 +181,21 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Download Java (temurin@8)
+        id: download-java-temurin-8
+        if: matrix.java == 'temurin@8'
+        uses: typelevel/download-java@v1
+        with:
+          distribution: temurin
+          java-version: 8
+
       - name: Setup Java (temurin@8)
         if: matrix.java == 'temurin@8'
         uses: actions/setup-java@v2
         with:
-          distribution: temurin
+          distribution: jdkfile
           java-version: 8
+          jdkFile: ${{ steps.download-java-temurin-8.outputs.jdkFile }}
 
       - name: Cache sbt
         uses: actions/cache@v2

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/JavaSpec.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/JavaSpec.scala
@@ -26,7 +26,10 @@ final case class JavaSpec(dist: JavaSpec.Distribution, version: String) {
 object JavaSpec {
 
   def temurin(version: String): JavaSpec = JavaSpec(Distribution.Temurin, version)
+  def corretto(version: String): JavaSpec = JavaSpec(Distribution.Corretto, version)
   def graalvm(version: String): JavaSpec = JavaSpec(Distribution.GraalVM, version)
+  def openj9(version: String): JavaSpec = JavaSpec(Distribution.OpenJ9, version)
+  def oracle(version: String): JavaSpec = JavaSpec(Distribution.Oracle, version)
 
   @deprecated(
     "Use single-arg overload to get the latest GraalVM for a Java version. If you need a specific GraalVM then use JavaSpec(Distribution.GraalVM(graal), version)",

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/JavaSpec.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/JavaSpec.scala
@@ -29,13 +29,26 @@ object JavaSpec {
   def graalvm(graal: String, version: String): JavaSpec =
     JavaSpec(Distribution.GraalVM(graal), version)
 
-  sealed abstract class Distribution(val rendering: String) extends Product with Serializable
+  sealed abstract class Distribution(val rendering: String) extends Product with Serializable {
+    private[gha] def isTlIndexed: Boolean = false
+  }
+
+  // marker for distributions in the typelevel jdk index
+  private[gha] sealed abstract class TlDistribution(rendering: String)
+      extends Distribution(rendering) {
+    override def isTlIndexed = true
+  }
 
   object Distribution {
-    case object Temurin extends Distribution("temurin")
+    case object Temurin extends TlDistribution("temurin")
+    case object Corretto extends TlDistribution("corretto")
+    case object GraalVM extends TlDistribution("graalvm")
+    case object OpenJ9 extends TlDistribution("openj9")
+    case object Oracle extends TlDistribution("oracle")
+
     case object Zulu extends Distribution("zulu")
+    @deprecated("AdoptOpenJDK been transitioned to Adoptium Temurin", "0.4.6")
     case object Adopt extends Distribution("adopt-hotspot")
-    case object OpenJ9 extends Distribution("adopt-openj9")
     case object Liberica extends Distribution("liberica")
     final case class GraalVM(version: String) extends Distribution(version)
   }

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/JavaSpec.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/JavaSpec.scala
@@ -26,6 +26,11 @@ final case class JavaSpec(dist: JavaSpec.Distribution, version: String) {
 object JavaSpec {
 
   def temurin(version: String): JavaSpec = JavaSpec(Distribution.Temurin, version)
+  def graalvm(version: String): JavaSpec = JavaSpec(Distribution.GraalVM, version)
+
+  @deprecated(
+    "Use single-arg overload to get the latest GraalVM for a Java version. If you need a specific GraalVM then use JavaSpec(Distribution.GraalVM(graal), version)",
+    "0.4.6")
   def graalvm(graal: String, version: String): JavaSpec =
     JavaSpec(Distribution.GraalVM(graal), version)
 

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/JavaSpec.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/JavaSpec.scala
@@ -27,7 +27,7 @@ object JavaSpec {
 
   def temurin(version: String): JavaSpec = JavaSpec(Distribution.Temurin, version)
   def corretto(version: String): JavaSpec = JavaSpec(Distribution.Corretto, version)
-  def graalvm(version: String): JavaSpec = JavaSpec(Distribution.GraalVM, version)
+  def graalvm(version: String): JavaSpec = JavaSpec(Distribution.LatestGraalVM, version)
   def openj9(version: String): JavaSpec = JavaSpec(Distribution.OpenJ9, version)
   def oracle(version: String): JavaSpec = JavaSpec(Distribution.Oracle, version)
 
@@ -50,7 +50,7 @@ object JavaSpec {
   object Distribution {
     case object Temurin extends TlDistribution("temurin")
     case object Corretto extends TlDistribution("corretto")
-    case object GraalVM extends TlDistribution("graalvm")
+    case object LatestGraalVM extends TlDistribution("graalvm")
     case object OpenJ9 extends TlDistribution("openj9")
     case object Oracle extends TlDistribution("oracle")
 


### PR DESCRIPTION
Closes https://github.com/typelevel/sbt-typelevel/issues/107. Integrates sbt-typelevel with [typelevel/jdk-index](https://github.com/typelevel/jdk-index) and [typelevel/download-java](https://github.com/typelevel/download-java).

Not all the distributions currently made available in the plugin are included in the typelevel/jdk-index, so these fallback to the old workflow steps. And similar for specific versions of GraalVM, since the index always points to the latest.

There will be minor breakage if someone was specifying a _full_ Java version (`"17"` vs `"17.0.2"`) but that's probably pretty unusual and not a good idea in general. We may want to consider requiring an `Int` here in the future instead of a `String`.

cc @vasilmkd