### PR TITLE
Add `tlSitePreview`

### DIFF
--- a/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
+++ b/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
@@ -111,8 +111,7 @@ object TypelevelSitePlugin extends AutoPlugin {
         .allocated
         .unsafeRunSync()
 
-      logger.info(
-        s"Preview server started on port ${previewConfig.port}. Press ctrl-D to exit.")
+      logger.info(s"Preview server started on port ${previewConfig.port}.")
 
       (Compile / runMain)
         // watch but no-livereload b/c we don't need an mdoc server


### PR DESCRIPTION
This PR adds a single command `tlSitePreview` which runs both `mdoc --watch` and `laikaPreview` simultaneously, for a cohesive live-reload editing experience. Thanks to @Quafadas for reminding me about this in https://github.com/typelevel/sbt-typelevel/issues/186#issuecomment-1050321968.

cc @jenshalm (sorry for all the noise this week!): I thought you may be interested what this looks like, since you also mentioned this problem while working on the http4s site.

Unfortunately I had to copy the implementation of `laikaPreview` here. But, I wonder if the next version of Laika can define a `Task[() => ()]` `laikaStartPreview` that starts the server and returns the shutdown hook. `laikaPreview` can then be implemented using that, but it also makes it easier to integrate with other tooling like mdoc.