### PR TITLE
Better versioning in site plugin

### DIFF
--- a/kernel/src/main/scala/org/typelevel/sbt/kernel/GitHelper.scala
+++ b/kernel/src/main/scala/org/typelevel/sbt/kernel/GitHelper.scala
@@ -27,11 +27,12 @@ private[sbt] object GitHelper {
    * @param fromHead
    *   if `true`, only tags reachable from HEAD's history. If `false`, all tags in the repo.
    */
-  def previousReleases(fromHead: Boolean = false): List[V] =
+  def previousReleases(fromHead: Boolean = false, strict: Boolean = true): List[V] =
     Try {
       val merged = if (fromHead) " --merged HEAD" else ""
       // --no-contains omits tags on HEAD
-      s"git -c versionsort.suffix=- tag --no-contains HEAD$merged --sort=-v:refname" // reverse
+      val noContains = if (strict) " --no-contains HEAD" else ""
+      s"git -c versionsort.suffix=- tag$noContains$merged --sort=-v:refname" // reverse
         .!!
         .split("\n")
         .toList

--- a/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
+++ b/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
@@ -253,7 +253,7 @@ object TypelevelSitePlugin extends AutoPlugin {
     // and there are no stable releases it is bincompatible with,
     // then for all effective purposes it is the current release
 
-    val release = GitHelper.previousReleases(fromHead = true) match {
+    val release = GitHelper.previousReleases(fromHead = true, strict = false) match {
       case head :: tail if head.isPrerelease =>
         tail
           .filterNot(_.isPrerelease)
@@ -267,7 +267,7 @@ object TypelevelSitePlugin extends AutoPlugin {
 
   // latest tagged release, including pre-releases
   private lazy val currentPreRelease = Def.setting {
-    GitHelper.previousReleases(fromHead = true).headOption.map(_.toString)
+    GitHelper.previousReleases(fromHead = true, strict = false).headOption.map(_.toString)
   }
 
   private def previewTask = Def


### PR DESCRIPTION
1. Add a `PRERELEASE_VERSION` mdoc variable, which is guaranteed to be the latest released version _including pre-releases_ (Ms, RCs, etc.). This is in addition to existing `VERSION` (the latest stable release) and `SNAPSHOT_VERSION` (the current version in the build).
2. If there are no stable releases in the current _binary series_, let the `VERSION` variable adopt the latest pre-release version instead.
3. When looking for the latest `VERSION`, consider both current _and_ previous tags (i.e., not _strictly_ previous).