### PR TITLE
Proposal: Add `mimaReportBinaryIssues` to the `prePR` command

### DIFF
--- a/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
+++ b/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
@@ -91,6 +91,7 @@ object TypelevelPlugin extends AutoPlugin {
         "scalafmtSbt",
         "set ThisBuild / tlFatalWarnings := tlFatalWarningsInCi.value",
         "Test / compile",
+        "mimaReportBinaryIssues",
         "reload"
       )
     )

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -35,7 +35,7 @@ ThisBuild / tlVersionIntroduced := Map("3" -> "0.4.2")
 
 ## How do I locally prepare my PR for CI?
 
-**sbt-typelevel** comes with a `prePR` command, which updates the GitHub workflow, generates headers, runs `scalafmt`, and clean compiles your code.
+**sbt-typelevel** comes with a `prePR` command, which updates the GitHub workflow, generates headers, runs `scalafmt`, checks binary compatibility via MiMa tool, and clean compiles your code.
 
 You may also want to (globally) install the [sbt-rewarn](https://github.com/rtimush/sbt-rewarn) plugin to help you identify and resolve compiler warnings, which by default are fatal in CI.
 


### PR DESCRIPTION
I noticed that `prePR` doesn't contain the `mimaReportBinaryIssues`. Is it intentional? I want to promote using the `prePR` in several projects, so binary compatibility checking is an important step.