### PR TITLE
Enable syntax highlighting for Scala 3 automatically

### DIFF
--- a/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
+++ b/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
@@ -37,6 +37,7 @@ import MdocPlugin.autoImport._
 import LaikaPlugin.autoImport._
 import gha.GenerativePlugin
 import GenerativePlugin.autoImport._
+import TypelevelKernelPlugin.autoImport._
 
 object TypelevelSitePlugin extends AutoPlugin {
 
@@ -117,7 +118,8 @@ object TypelevelSitePlugin extends AutoPlugin {
     },
     tlSiteHeliumExtensions := TypelevelHeliumExtensions(
       licenses.value.headOption,
-      tlSiteRelatedProjects.value
+      tlSiteRelatedProjects.value,
+      tlIsScala3.value
     ),
     tlSiteApiUrl := {
       val javadocioUrl = for {

--- a/site/src/main/scala/org/typelevel/sbt/site/TypelevelHeliumExtensions.scala
+++ b/site/src/main/scala/org/typelevel/sbt/site/TypelevelHeliumExtensions.scala
@@ -23,6 +23,7 @@ import laika.config.Config
 import laika.io.model.InputTree
 import laika.markdown.github.GitHubFlavor
 import laika.parse.code.SyntaxHighlighting
+import laika.parse.code.languages.DottySyntax
 import laika.rewrite.DefaultTemplatePath
 import laika.theme.Theme
 import laika.theme.ThemeBuilder
@@ -32,9 +33,14 @@ import java.net.URL
 
 object TypelevelHeliumExtensions {
 
+  @deprecated("Use overload with scala3 parameter", "0.4.7")
+  def apply(license: Option[(String, URL)], related: Seq[(String, URL)]): ThemeProvider =
+    apply(license, related, false)
+
   def apply(
       license: Option[(String, URL)],
-      related: Seq[(String, URL)]
+      related: Seq[(String, URL)],
+      scala3: Boolean
   ): ThemeProvider = new ThemeProvider {
     def build[F[_]](implicit F: Sync[F]): Resource[F, Theme[F]] =
       ThemeBuilder[F]("Typelevel Helium Extensions")
@@ -49,7 +55,11 @@ object TypelevelHeliumExtensions {
               Path.Root / "site" / "styles.css"
             )
         )
-        .addExtensions(GitHubFlavor, SyntaxHighlighting)
+        .addExtensions(
+          GitHubFlavor,
+          if (scala3) SyntaxHighlighting.withSyntaxBinding("scala", DottySyntax)
+          else SyntaxHighlighting
+        )
         .addBaseConfig(licenseConfig(license).withFallback(relatedConfig(related)))
         .build
   }


### PR DESCRIPTION
Laika defaults to Scala 2 highlighting for `scala` sources, see:
- https://github.com/planet42/Laika/discussions/268