### PR TITLE
Revert "Update mdoc, sbt-mdoc to 2.3.0"

### DIFF
--- a/site/build.sbt
+++ b/site/build.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.3.0")
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.24")
 addSbtPlugin("org.planet42" % "laika-sbt" % "0.18.1")


### PR DESCRIPTION
Reverts typelevel/sbt-typelevel#112

Mdoc 2.3.x is currently plagued by:
- https://github.com/scalameta/mdoc/issues/615