### PR TITLE
Update sbt-mdoc to 2.3.2

### DIFF
--- a/site/build.sbt
+++ b/site/build.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.24")
+addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.3.2")
 addSbtPlugin("org.planet42" % "laika-sbt" % "0.18.2")


### PR DESCRIPTION
This PR updates us to sbt-mdoc 2.3.2 which includes the Polytype fix for PPrint thus resolving the issue motivating https://github.com/typelevel/sbt-typelevel/pull/224

https://github.com/com-lihaoyi/PPrint/pull/79
https://github.com/scalameta/mdoc/pull/636
