### PR TITLE
Use SJS linker batch mode in CI

### DIFF
--- a/github/src/main/scala/org/typelevel/sbt/TypelevelScalaJSGitHubPlugin.scala
+++ b/github/src/main/scala/org/typelevel/sbt/TypelevelScalaJSGitHubPlugin.scala
@@ -26,6 +26,7 @@ object TypelevelScalaJSGitHubPlugin extends AutoPlugin {
   override def requires = ScalaJSPlugin && TypelevelKernelPlugin
 
   import TypelevelKernelPlugin.autoImport._
+  import ScalaJSPlugin.autoImport._
 
   override def projectSettings = Seq(
     scalacOptions ++= {
@@ -43,6 +44,9 @@ object TypelevelScalaJSGitHubPlugin extends AutoPlugin {
           s"$flag$l->$g"
         }
       }
+    },
+    scalaJSLinkerConfig := {
+      scalaJSLinkerConfig.value.withBatchMode(sys.env.get("GITHUB_ACTIONS").contains("true"))
     }
   )
 }


### PR DESCRIPTION
According to scaladoc:

> In batch mode, the linker can throw away intermediate state that is otherwise maintained for incremental runs.

No idea if it will make a meaningful difference, but we definitely don't need incremental state in CI.