### PR TITLE
Move `tlFatalWarnings` and `tlJdkRelease` into per-config scope

### DIFF
--- a/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
+++ b/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
@@ -72,12 +72,6 @@ object TypelevelSettingsPlugin extends AutoPlugin {
       }
     },
     scalacOptions ++= {
-      if (tlFatalWarnings.value)
-        Seq("-Xfatal-warnings")
-      else
-        Seq.empty
-    },
-    scalacOptions ++= {
       val warningsNsc = Seq("-Xlint", "-Ywarn-dead-code")
 
       val warnings211 =
@@ -199,7 +193,16 @@ object TypelevelSettingsPlugin extends AutoPlugin {
       "-encoding",
       "utf8",
       "-Xlint:all"
-    ),
+    )
+  ) ++ inConfig(Compile)(perConfigSettings) ++ inConfig(Test)(perConfigSettings)
+
+  private val perConfigSettings = Seq(
+    scalacOptions ++= {
+      if (tlFatalWarnings.value)
+        Seq("-Xfatal-warnings")
+      else
+        Seq.empty
+    },
     javacOptions ++= {
       if (tlFatalWarnings.value)
         Seq("-Werror")


### PR DESCRIPTION
Fixes https://github.com/typelevel/sbt-typelevel/issues/201.

TIL `inConfig`. This change should make it possible to set different values for these settings in the `Compile` and `Test` scopes. Examples:
- fatal warnings in compile, disabled in test
- JDK 8 in compile, JDK 11 in test