### PR TITLE
Smarter SCM info detection

### DIFF
--- a/github/src/main/scala/org/typelevel/sbt/TypelevelGitHubPlugin.scala
+++ b/github/src/main/scala/org/typelevel/sbt/TypelevelGitHubPlugin.scala
@@ -43,6 +43,7 @@ object TypelevelGitHubPlugin extends AutoPlugin {
     tlGitHubRepo := gitHubUserRepo.value.map(_._2),
     scmInfo := gitHubUserRepo.value.map {
       case (user, repo) =>
+        sLog.value.info(s"set scmInfo to https://github.com/$user/$repo")
         gitHubScmInfo(user, repo)
     },
     homepage := homepage.value.orElse(scmInfo.value.map(_.browseUrl))
@@ -55,7 +56,7 @@ object TypelevelGitHubPlugin extends AutoPlugin {
       s"scm:git:git@github.com:$user/$repo.git"
     )
 
-  private[sbt] def gitHubUserRepo = Def.setting {
+  private[sbt] lazy val gitHubUserRepo = Def.setting {
     import scala.sys.process._
 
     def fromRemote(remote: String) = {

--- a/github/src/main/scala/org/typelevel/sbt/TypelevelGitHubPlugin.scala
+++ b/github/src/main/scala/org/typelevel/sbt/TypelevelGitHubPlugin.scala
@@ -58,19 +58,23 @@ object TypelevelGitHubPlugin extends AutoPlugin {
   private[sbt] def gitHubUserRepo = Def.setting {
     import scala.sys.process._
 
-    val identifier = """([^\/]+?)"""
-    val GitHubHttps = s"https://github.com/$identifier/$identifier(?:\\.git)?".r
-    val GitHubGit = s"git://github.com:$identifier/$identifier(?:\\.git)?".r
-    val GitHubSsh = s"git@github.com:$identifier/$identifier(?:\\.git)?".r
-    Try {
-      val remote = List("git", "ls-remote", "--get-url", "origin").!!.trim()
-      remote match {
-        case GitHubHttps(user, repo) => Some((user, repo))
-        case GitHubGit(user, repo) => Some((user, repo))
-        case GitHubSsh(user, repo) => Some((user, repo))
-        case _ => None
-      }
-    }.toOption.flatten
+    def fromRemote(remote: String) = {
+      val identifier = """([^\/]+?)"""
+      val GitHubHttps = s"https://github.com/$identifier/$identifier(?:\\.git)?".r
+      val GitHubGit = s"git://github.com:$identifier/$identifier(?:\\.git)?".r
+      val GitHubSsh = s"git@github.com:$identifier/$identifier(?:\\.git)?".r
+      Try {
+        List("git", "ls-remote", "--get-url", remote).!!.trim() match {
+          case GitHubHttps(user, repo) => Some((user, repo))
+          case GitHubGit(user, repo) => Some((user, repo))
+          case GitHubSsh(user, repo) => Some((user, repo))
+          case _ => None
+        }
+      }.toOption.flatten
+    }
+
+    // upstream if this is a fork, otherwise fallback to origin
+    fromRemote("upstream").orElse(fromRemote("origin"))
   }
 
 }


### PR DESCRIPTION
Fixes https://github.com/typelevel/sbt-typelevel/issues/249. Two changes:
1. First check for an `upstream` remote, then fallback to `origin`. This way forks do the right thing.
2. Log the detected SCM info in the console, to avoid future oopsies.