### PR TITLE
Revert #250 which moved scalac/javac options to scope-specific settings

### DIFF
--- a/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
+++ b/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
@@ -195,10 +195,9 @@ object TypelevelSettingsPlugin extends AutoPlugin {
       "-encoding",
       "utf8",
       "-Xlint:all"
-    )
-  ) ++ inConfig(Compile)(perConfigSettings) ++ inConfig(Test)(perConfigSettings)
+    ),
 
-  private val perConfigSettings = Seq(
+    // TODO make these respect Compile/Test config
     scalacOptions ++= {
       if (tlFatalWarnings.value)
         Seq("-Xfatal-warnings")
@@ -237,7 +236,10 @@ object TypelevelSettingsPlugin extends AutoPlugin {
     },
     javacOptions ++= {
       withJdkRelease(tlJdkRelease.value)(Seq.empty[String])(n => Seq("--release", n.toString))
-    },
+    }
+  ) ++ inConfig(Compile)(perConfigSettings) ++ inConfig(Test)(perConfigSettings)
+
+  private val perConfigSettings = Seq(
     unmanagedSourceDirectories ++= {
       def extraDirs(suffix: String) =
         if (crossProjectPlatform.?.value.isDefined)


### PR DESCRIPTION
Fixes https://github.com/typelevel/sbt-typelevel/issues/253 by effectively reverting https://github.com/typelevel/sbt-typelevel/pull/250.

I though I was very clever in https://github.com/typelevel/sbt-typelevel/pull/250 but I neglected to realize that the `Test` config inherits from the `Compile` config. So, if you setting scalac and javac options additively, then the settings in the `Test` scope are not independent of those in `Compile`.

sbt-tpolecat recently navigated this in https://github.com/DavidGregory084/sbt-tpolecat/pull/58, and AFAICT was able to do so because its sets scalac options all at once e.g. `:=` instead of `++=`. But that's too big a change for now.