### PR TITLE
Add typelevel.g8 section to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,9 @@ sbt-typelevel configures [sbt](https://www.scala-sbt.org/) for developing, testi
 
 ## Get Started
 
-Visit https://typelevel.org/sbt-typelevel for a quick start example and detailed documentation.
-
-## Giter8 Template
-
 ```sh
 sbt new typelevel/typelevel.g8
 ```
 
-Find the Giter8 template companion project at [typelevel.g8](https://github.com/typelevel/typelevel.g8)
+Visit https://typelevel.org/sbt-typelevel for a quick start example and detailed documentation.
+Find the Giter8 template companion project at [typelevel.g8](https://github.com/typelevel/typelevel.g8).

--- a/README.md
+++ b/README.md
@@ -17,4 +17,8 @@ Visit https://typelevel.org/sbt-typelevel for a quick start example and detailed
 
 ## Giter8 Template
 
+```sh
+sbt new typelevel/typelevel.g8
+```
+
 Find the Giter8 template companion project at [typelevel.g8](https://github.com/typelevel/typelevel.g8)

--- a/README.md
+++ b/README.md
@@ -14,3 +14,7 @@ sbt-typelevel configures [sbt](https://www.scala-sbt.org/) for developing, testi
 ## Get Started
 
 Visit https://typelevel.org/sbt-typelevel for a quick start example and detailed documentation.
+
+## Giter8 Template
+
+Find the Giter8 template companion project at [typelevel.g8](https://github.com/typelevel/typelevel.g8)

--- a/build.sbt
+++ b/build.sbt
@@ -178,6 +178,7 @@ lazy val docs = project
     laikaConfig ~= { _.withRawContent },
     tlSiteApiPackage := Some("org.typelevel.sbt"),
     tlSiteRelatedProjects := Seq(
+      "typelevel.g8" -> url("https://github.com/typelevel/typelevel.g8"),
       "sbt" -> url("https://www.scala-sbt.org/"),
       "sbt-crossproject" -> url("https://github.com/portable-scala/sbt-crossproject"),
       "mima" -> url("https://github.com/lightbend/mima"),

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,7 @@ addSbtPlugin("org.typelevel" % "sbt-typelevel-ci-release" % "@VERSION@")
 
 ### Giter8 Template
 
-The sbt-typelevel project provides a [Giter8 template](http://www.foundweekends.org/giter8/index.html) for quickly starting projects with familiar workflows and best practices.
+We provide a [Giter8 template](http://www.foundweekends.org/giter8/index.html) for quickly starting projects with familiar workflows and best practices.
 
 ```sh
 sbt new typelevel/typelevel.g8

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,7 @@ We provide a [Giter8 template](http://www.foundweekends.org/giter8/index.html) f
 sbt new typelevel/typelevel.g8
 ```
 
-This will help you create a new project with sbt-typelevel, sbt-typelevel-site, and some other boilerplate setup.
+This will guide you through the basic setup to create a new project with **sbt-typelevel** and **sbt-typelevel-site**.
 Check out the project repo for more details: [typelevel.g8](https://github.com/typelevel/typelevel.g8)
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,7 +50,7 @@ sbt new typelevel/typelevel.g8
 ```
 
 This will guide you through the basic setup to create a new project with **sbt-typelevel** and **sbt-typelevel-site**.
-Check out the project repo for more details: [typelevel.g8](https://github.com/typelevel/typelevel.g8)
+Check out the [typelevel.g8](https://github.com/typelevel/typelevel.g8) project for more details.
 
 
 ### Configure Your Build

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,20 @@ sbt-typelevel configures [sbt](https://www.scala-sbt.org/) for developing, testi
 [![sbt-typelevel Scala version support](https://index.scala-lang.org/typelevel/sbt-typelevel/sbt-typelevel/latest-by-scala-version.svg?targetType=Sbt)](https://index.scala-lang.org/typelevel/sbt-typelevel/sbt-typelevel)
 [![Discord](https://img.shields.io/discord/632277896739946517.svg?label=&logo=discord&logoColor=ffffff&color=404244&labelColor=6A7EC2)](https://discord.gg/D7wY3aH7BQ)
 
+### Giter8 Template
+
+We provide a [Giter8 template](http://www.foundweekends.org/giter8/index.html) for quickly starting projects with familiar workflows and best practices.
+
+```sh
+sbt new typelevel/typelevel.g8
+```
+
+This will guide you through the basic setup to create a new project with **sbt-typelevel** and **sbt-typelevel-site**.
+Check out the [typelevel.g8](https://github.com/typelevel/typelevel.g8) project for more details.
+
+
+### Plugins
+
 Pick either the **sbt-typelevel** (recommended) or **sbt-typelevel-ci-release** plugin.
 
 #### `project/plugins.sbt`
@@ -39,18 +53,6 @@ addSbtPlugin("org.typelevel" % "sbt-typelevel-ci-release" % "@VERSION@")
 3. A `prePR` command and other nice-to-haves.
 
 @:@
-
-
-### Giter8 Template
-
-We provide a [Giter8 template](http://www.foundweekends.org/giter8/index.html) for quickly starting projects with familiar workflows and best practices.
-
-```sh
-sbt new typelevel/typelevel.g8
-```
-
-This will guide you through the basic setup to create a new project with **sbt-typelevel** and **sbt-typelevel-site**.
-Check out the [typelevel.g8](https://github.com/typelevel/typelevel.g8) project for more details.
 
 
 ### Configure Your Build

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,20 @@ addSbtPlugin("org.typelevel" % "sbt-typelevel-ci-release" % "@VERSION@")
 
 @:@
 
-Then configure your build.
+
+### Giter8 Template
+
+The sbt-typelevel project provides a [Giter8 template](http://www.foundweekends.org/giter8/index.html) for quickly starting projects with familiar workflows and best practices.
+
+```sh
+sbt new typelevel/typelevel.g8
+```
+
+This will help you create a new project with sbt-typelevel, sbt-typelevel-site, and some other boilerplate setup.
+Check out the project repo for more details: [typelevel.g8](https://github.com/typelevel/typelevel.g8)
+
+
+### Configure Your Build
 
 #### `build.sbt`
 


### PR DESCRIPTION
This PR adds a typelevel.g8 section to the index as part of the Quick Start section.
Additionally, it adds a link to the README.


![sbt-typelevel-g8-docs](https://user-images.githubusercontent.com/5440389/163685370-e9b8d4a2-1091-4776-87bf-fb03ee69e525.png)


