### PR TITLE
Use Jitpack.io to host snapshot Scaladoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ target/
 
 .sbtopts
 
+# Mac OS
+.DS_Store
+
 # vim
 *.sw?
 

--- a/build.sbt
+++ b/build.sbt
@@ -103,7 +103,7 @@ lazy val sonatype = project
   .settings(
     name := "sbt-typelevel-sonatype"
   )
-  .dependsOn(kernel)
+  .dependsOn(kernel, github)
 
 lazy val ciSigning = project
   .in(file("ci-signing"))

--- a/sonatype/src/main/scala/org/typelevel/sbt/TypelevelSonatypePlugin.scala
+++ b/sonatype/src/main/scala/org/typelevel/sbt/TypelevelSonatypePlugin.scala
@@ -78,7 +78,7 @@ object TypelevelSonatypePlugin extends AutoPlugin {
           scalaBinaryVersion.value
         )
 
-        (user, repo) <- TypelevelGitHubPlugin.gitHubUserRepo.value
+        (user, repo) <- TypelevelGitHubPlugin.gitHubOriginUserRepo.value
 
         snapshotTagOrHash <- GitHelper.getTagOrHash(
           git.gitCurrentTags.value,


### PR DESCRIPTION
Resolves #226 as suggested on the ticket discussion.

Can you foresee any problems arising from making the sonatype plugin depend on the github plugin?

This seems to work fine within sbt-typelevel itself as far as I can tell. I think that the usage of `TypelevelUnidocsPlugin` points every submodule to the unidoc artifact as it sets `ThisBuild \ apiURL`:

```
sbt:sbt-typelevel> show apiURL
[info] noPublish / apiURL
[info] 	Some(https://javadoc.jitpack.io/com/github/typelevel/sbt-typelevel/sbt-typelevel-docs_2.12/344a315c517b39d93e85d3eb3b0131c2261b00fe/)
[info] ci / apiURL
[info] 	Some(https://javadoc.jitpack.io/com/github/typelevel/sbt-typelevel/sbt-typelevel-docs_2.12/344a315c517b39d93e85d3eb3b0131c2261b00fe/)
[info] core / apiURL
[info] 	Some(https://javadoc.jitpack.io/com/github/typelevel/sbt-typelevel/sbt-typelevel-docs_2.12/344a315c517b39d93e85d3eb3b0131c2261b00fe/)
[info] site / apiURL
[info] 	Some(https://javadoc.jitpack.io/com/github/typelevel/sbt-typelevel/sbt-typelevel-docs_2.12/344a315c517b39d93e85d3eb3b0131c2261b00fe/)
[info] github / apiURL
[info] 	Some(https://javadoc.jitpack.io/com/github/typelevel/sbt-typelevel/sbt-typelevel-docs_2.12/344a315c517b39d93e85d3eb3b0131c2261b00fe/)
[info] versioning / apiURL
[info] 	Some(https://javadoc.jitpack.io/com/github/typelevel/sbt-typelevel/sbt-typelevel-docs_2.12/344a315c517b39d93e85d3eb3b0131c2261b00fe/)
[info] ciSigning / apiURL
[info] 	Some(https://javadoc.jitpack.io/com/github/typelevel/sbt-typelevel/sbt-typelevel-docs_2.12/344a315c517b39d93e85d3eb3b0131c2261b00fe/)
[info] mima / apiURL
[info] 	Some(https://javadoc.jitpack.io/com/github/typelevel/sbt-typelevel/sbt-typelevel-docs_2.12/344a315c517b39d93e85d3eb3b0131c2261b00fe/)
[info] ciRelease / apiURL
[info] 	Some(https://javadoc.jitpack.io/com/github/typelevel/sbt-typelevel/sbt-typelevel-docs_2.12/344a315c517b39d93e85d3eb3b0131c2261b00fe/)
[info] settings / apiURL
[info] 	Some(https://javadoc.jitpack.io/com/github/typelevel/sbt-typelevel/sbt-typelevel-docs_2.12/344a315c517b39d93e85d3eb3b0131c2261b00fe/)
[info] docs / apiURL
[info] 	Some(https://javadoc.jitpack.io/com/github/typelevel/sbt-typelevel/sbt-typelevel-docs_2.12/344a315c517b39d93e85d3eb3b0131c2261b00fe/)
[info] githubActions / apiURL
[info] 	Some(https://javadoc.jitpack.io/com/github/typelevel/sbt-typelevel/sbt-typelevel-docs_2.12/344a315c517b39d93e85d3eb3b0131c2261b00fe/)
[info] mergify / apiURL
[info] 	Some(https://javadoc.jitpack.io/com/github/typelevel/sbt-typelevel/sbt-typelevel-docs_2.12/344a315c517b39d93e85d3eb3b0131c2261b00fe/)
[info] unidoc / apiURL
[info] 	Some(https://javadoc.jitpack.io/com/github/typelevel/sbt-typelevel/sbt-typelevel-docs_2.12/344a315c517b39d93e85d3eb3b0131c2261b00fe/)
[info] sonatypeCiRelease / apiURL
[info] 	Some(https://javadoc.jitpack.io/com/github/typelevel/sbt-typelevel/sbt-typelevel-docs_2.12/344a315c517b39d93e85d3eb3b0131c2261b00fe/)
[info] sonatype / apiURL
[info] 	Some(https://javadoc.jitpack.io/com/github/typelevel/sbt-typelevel/sbt-typelevel-docs_2.12/344a315c517b39d93e85d3eb3b0131c2261b00fe/)
[info] kernel / apiURL
[info] 	Some(https://javadoc.jitpack.io/com/github/typelevel/sbt-typelevel/sbt-typelevel-docs_2.12/344a315c517b39d93e85d3eb3b0131c2261b00fe/)
[info] apiURL
[info] 	Some(https://javadoc.jitpack.io/com/github/typelevel/sbt-typelevel/sbt-typelevel-docs_2.12/344a315c517b39d93e85d3eb3b0131c2261b00fe/)
```