### PR TITLE
Add API mappings for Java

### DIFF
--- a/site/src/main/scala/org/typelevel/sbt/site/TypelevelHeliumExtensions.scala
+++ b/site/src/main/scala/org/typelevel/sbt/site/TypelevelHeliumExtensions.scala
@@ -37,6 +37,14 @@ object TypelevelHeliumExtensions {
   def apply(license: Option[(String, URL)], related: Seq[(String, URL)]): ThemeProvider =
     apply(license, related, false)
 
+  /**
+   * @param license
+   *   name and [[java.net.URL]] of project license
+   * @param related
+   *   name and [[java.net.URL]] of related projects
+   * @param scala3
+   *   whether to use Scala 3 syntax highlighting
+   */
   def apply(
       license: Option[(String, URL)],
       related: Seq[(String, URL)],


### PR DESCRIPTION
scaladoc before 2.13 doesn't resolve links into the Java SE javadocs.  This adds fallback apiMappings for various JVMs so `doc` tasks don't crash.