### PR TITLE
Add Scalafix integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,9 @@ jobs:
       - name: Check that workflows are up to date
         run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' 'project /' githubWorkflowCheck
 
-      - name: Check headers and formatting
+      - name: Check headers, migrations and formatting
         if: matrix.java == 'temurin@8'
-        run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' headerCheckAll scalafmtCheckAll 'project /' scalafmtSbtCheck
+        run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' headerCheckAll scalafmtCheckAll 'scalafixAll --check' 'project /' scalafmtSbtCheck
 
       - name: Test
         run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' test
@@ -81,11 +81,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p github/target github-actions/target kernel/target versioning/target ci-release/target .jvm/target mdocs/target site/target ci-signing/target mergify/target unidoc/target .native/target mima/target no-publish/target sonatype/target ci/target sonatype-ci-release/target core/target settings/target target .js/target project/target
+        run: mkdir -p github/target github-actions/target kernel/target versioning/target ci-release/target scalafix/target .jvm/target mdocs/target site/target ci-signing/target mergify/target unidoc/target .native/target mima/target no-publish/target sonatype/target ci/target sonatype-ci-release/target core/target settings/target target .js/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar github/target github-actions/target kernel/target versioning/target ci-release/target .jvm/target mdocs/target site/target ci-signing/target mergify/target unidoc/target .native/target mima/target no-publish/target sonatype/target ci/target sonatype-ci-release/target core/target settings/target target .js/target project/target
+        run: tar cf targets.tar github/target github-actions/target kernel/target versioning/target ci-release/target scalafix/target .jvm/target mdocs/target site/target ci-signing/target mergify/target unidoc/target .native/target mima/target no-publish/target sonatype/target ci/target sonatype-ci-release/target core/target settings/target target .js/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ tags
 .bloop/
 metals.sbt
 .vscode
+
+# Mac OS
+.DS_Store

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -112,6 +112,14 @@ pull_request_rules:
       add:
       - no-publish
       remove: []
+- name: Label scalafix PRs
+  conditions:
+  - files~=^scalafix/
+  actions:
+    label:
+      add:
+      - scalafix
+      remove: []
 - name: Label settings PRs
   conditions:
   - files~=^settings/

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,7 @@
+rules = [
+    OrganizeImports
+]
+
+OrganizeImports {
+  preset = INTELLIJ_2020_3
+}

--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,7 @@ lazy val `sbt-typelevel` = tlCrossRootProject.aggregate(
   versioning,
   mima,
   sonatype,
+  scalafix,
   ciSigning,
   sonatypeCiRelease,
   ci,
@@ -104,6 +105,14 @@ lazy val sonatype = project
   )
   .dependsOn(kernel)
 
+lazy val scalafix = project
+  .in(file("scalafix"))
+  .enablePlugins(SbtPlugin)
+  .settings(
+    name := "sbt-typelevel-scalafix"
+  )
+  .dependsOn(kernel)
+
 lazy val ciSigning = project
   .in(file("ci-signing"))
   .enablePlugins(SbtPlugin)
@@ -152,6 +161,7 @@ lazy val core = project
   )
   .dependsOn(
     ciRelease,
+    scalafix,
     settings
   )
 

--- a/ci-signing/src/main/scala/org/typelevel/sbt/TypelevelCiSigningPlugin.scala
+++ b/ci-signing/src/main/scala/org/typelevel/sbt/TypelevelCiSigningPlugin.scala
@@ -17,10 +17,11 @@
 package org.typelevel.sbt
 
 import io.crashbox.gpg.SbtGpg
-import sbt._, Keys._
-import org.typelevel.sbt.gha.GenerativePlugin
-import org.typelevel.sbt.gha.GitHubActionsPlugin
 import org.typelevel.sbt.gha.GenerativePlugin.autoImport._
+import org.typelevel.sbt.gha.{GenerativePlugin, GitHubActionsPlugin}
+import sbt._
+
+import Keys._
 
 object TypelevelCiSigningPlugin extends AutoPlugin {
 

--- a/ci/src/main/scala/org/typelevel/sbt/CrossRootProject.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/CrossRootProject.scala
@@ -16,8 +16,8 @@
 
 package org.typelevel.sbt
 
-import sbt._
 import org.typelevel.sbt.gha.GenerativePlugin.autoImport._
+import sbt._
 
 /**
  * Simultaneously creates a root project, a Scala JVM aggregate project, a Scala.js aggregate

--- a/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
@@ -16,11 +16,11 @@
 
 package org.typelevel.sbt
 
-import sbt._
-import org.typelevel.sbt.gha.GenerativePlugin
-import org.typelevel.sbt.gha.GitHubActionsPlugin
-import org.typelevel.sbt.gha.GenerativePlugin.autoImport._
 import com.typesafe.tools.mima.plugin.MimaPlugin
+import org.typelevel.sbt.gha.GenerativePlugin.autoImport._
+import org.typelevel.sbt.gha.{GenerativePlugin, GitHubActionsPlugin}
+import sbt._
+
 import scala.language.experimental.macros
 
 object TypelevelCiPlugin extends AutoPlugin {

--- a/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
+++ b/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
@@ -16,12 +16,13 @@
 
 package org.typelevel.sbt
 
-import sbt._, Keys._
-import org.typelevel.sbt.gha.GenerativePlugin
-import org.typelevel.sbt.gha.GitHubActionsPlugin
 import de.heikoseeberger.sbtheader.HeaderPlugin
+import org.typelevel.sbt.gha.{GenerativePlugin, GitHubActionsPlugin}
+import sbt._
 
 import scala.collection.immutable
+
+import Keys._
 
 object TypelevelPlugin extends AutoPlugin {
 
@@ -44,7 +45,6 @@ object TypelevelPlugin extends AutoPlugin {
   import TypelevelKernelPlugin.mkCommand
   import TypelevelSettingsPlugin.autoImport._
   import TypelevelSonatypeCiReleasePlugin.autoImport._
-  import TypelevelScalafixPlugin.autoImport._
   import GenerativePlugin.autoImport._
   import GitHubActionsPlugin.autoImport._
 

--- a/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
+++ b/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
@@ -29,6 +29,7 @@ object TypelevelPlugin extends AutoPlugin {
     TypelevelKernelPlugin &&
       TypelevelSettingsPlugin &&
       TypelevelCiReleasePlugin &&
+      TypelevelScalafixPlugin &&
       GitHubActionsPlugin &&
       HeaderPlugin
 
@@ -43,6 +44,7 @@ object TypelevelPlugin extends AutoPlugin {
   import TypelevelKernelPlugin.mkCommand
   import TypelevelSettingsPlugin.autoImport._
   import TypelevelSonatypeCiReleasePlugin.autoImport._
+  import TypelevelScalafixPlugin.autoImport._
   import GenerativePlugin.autoImport._
   import GitHubActionsPlugin.autoImport._
 
@@ -73,8 +75,8 @@ object TypelevelPlugin extends AutoPlugin {
     },
     githubWorkflowBuild := {
       WorkflowStep.Sbt(
-        List("headerCheckAll", "scalafmtCheckAll", "project /", "scalafmtSbtCheck"),
-        name = Some("Check headers and formatting"),
+        List("headerCheckAll", "scalafmtCheckAll", "scalafixAll --check", "project /", "scalafmtSbtCheck"),
+        name = Some("Check headers, migrations and formatting"),
         cond = Some(primaryJavaCond.value)
       ) +: githubWorkflowBuild.value
     }

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/GitHubActionsPlugin.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/GitHubActionsPlugin.scala
@@ -16,12 +16,13 @@
 
 package org.typelevel.sbt.gha
 
-import sbt._, Keys._
+import org.yaml.snakeyaml.Yaml
+import sbt._
 import sbt.io.Using
 
-import org.yaml.snakeyaml.Yaml
-
 import scala.collection.JavaConverters._
+
+import Keys._
 
 object GitHubActionsPlugin extends AutoPlugin {
 

--- a/github/src/main/scala/org/typelevel/sbt/TypelevelGitHubPlugin.scala
+++ b/github/src/main/scala/org/typelevel/sbt/TypelevelGitHubPlugin.scala
@@ -16,9 +16,11 @@
 
 package org.typelevel.sbt
 
-import sbt._, Keys._
+import sbt._
 
 import scala.util.Try
+
+import Keys._
 
 object TypelevelGitHubPlugin extends AutoPlugin {
 

--- a/github/src/main/scala/org/typelevel/sbt/TypelevelScalaJSGitHubPlugin.scala
+++ b/github/src/main/scala/org/typelevel/sbt/TypelevelScalaJSGitHubPlugin.scala
@@ -16,10 +16,12 @@
 
 package org.typelevel.sbt
 
-import sbt._, Keys._
-import org.scalajs.sbtplugin.ScalaJSPlugin
 import com.github.sbt.git.SbtGit.git
+import org.scalajs.sbtplugin.ScalaJSPlugin
 import org.typelevel.sbt.kernel.GitHelper
+import sbt._
+
+import Keys._
 
 object TypelevelScalaJSGitHubPlugin extends AutoPlugin {
   override def trigger = allRequirements

--- a/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
+++ b/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
@@ -16,8 +16,10 @@
 
 package org.typelevel.sbt
 
-import sbt._, Keys._
+import sbt._
 import sbt.plugins.JvmPlugin
+
+import Keys._
 
 object TypelevelKernelPlugin extends AutoPlugin {
 

--- a/kernel/src/main/scala/org/typelevel/sbt/kernel/GitHelper.scala
+++ b/kernel/src/main/scala/org/typelevel/sbt/kernel/GitHelper.scala
@@ -16,9 +16,8 @@
 
 package org.typelevel.sbt.kernel
 
-import scala.util.Try
-
 import scala.sys.process._
+import scala.util.Try
 
 private[sbt] object GitHelper {
 

--- a/mergify/src/main/scala/org/typelevel/sbt/mergify/MergifyPlugin.scala
+++ b/mergify/src/main/scala/org/typelevel/sbt/mergify/MergifyPlugin.scala
@@ -16,10 +16,12 @@
 
 package org.typelevel.sbt.mergify
 
-import sbt._, Keys._
 import org.typelevel.sbt.gha._
+import sbt._
 
 import java.nio.file.Path
+
+import Keys._
 
 object MergifyPlugin extends AutoPlugin {
 

--- a/mima/src/main/scala/org/typelevel/sbt/TypelevelMimaPlugin.scala
+++ b/mima/src/main/scala/org/typelevel/sbt/TypelevelMimaPlugin.scala
@@ -16,11 +16,12 @@
 
 package org.typelevel.sbt
 
-import sbt._, Keys._
 import com.typesafe.tools.mima.plugin.MimaPlugin
+import org.typelevel.sbt.kernel.{GitHelper, V}
+import sbt._
+
+import Keys._
 import MimaPlugin.autoImport._
-import org.typelevel.sbt.kernel.GitHelper
-import org.typelevel.sbt.kernel.V
 
 object TypelevelMimaPlugin extends AutoPlugin {
 

--- a/no-publish/src/main/scala/org/typelevel/sbt/NoPublishPlugin.scala
+++ b/no-publish/src/main/scala/org/typelevel/sbt/NoPublishPlugin.scala
@@ -16,7 +16,9 @@
 
 package org.typelevel.sbt
 
-import sbt._, Keys._
+import sbt._
+
+import Keys._
 
 object NoPublishPlugin extends AutoPlugin {
   override def trigger = noTrigger

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -13,6 +13,7 @@ val modules = List(
   "site",
   "sonatype",
   "sonatype-ci-release",
+  "scalafix",
   "versioning"
 )
 

--- a/project/scalafix.sbt
+++ b/project/scalafix.sbt
@@ -1,0 +1,1 @@
+../scalafix/build.sbt

--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.0")

--- a/scalafix/src/main/scala/org/typelevel/sbt/TypelevelScalafixPlugin.scala
+++ b/scalafix/src/main/scala/org/typelevel/sbt/TypelevelScalafixPlugin.scala
@@ -1,7 +1,9 @@
 package org.typelevel.sbt
 
-import sbt._, Keys._
+import sbt._
 import scalafix.sbt.ScalafixPlugin
+
+import Keys._
 import ScalafixPlugin.autoImport._
 
 object TypelevelScalafixPlugin extends AutoPlugin {

--- a/scalafix/src/main/scala/org/typelevel/sbt/TypelevelScalafixPlugin.scala
+++ b/scalafix/src/main/scala/org/typelevel/sbt/TypelevelScalafixPlugin.scala
@@ -1,0 +1,28 @@
+package org.typelevel.sbt
+
+import sbt._, Keys._
+import scalafix.sbt.ScalafixPlugin
+import ScalafixPlugin.autoImport._
+
+object TypelevelScalafixPlugin extends AutoPlugin {
+
+  override def requires = ScalafixPlugin
+
+  override def trigger = allRequirements
+
+  object autoImport {
+    val tlScalafixDependencies = settingKey[Seq[ModuleID]]("The scalafix rule dependencies to enable in the build.")
+  }
+
+  import autoImport._
+
+  override def buildSettings = Seq[Setting[_]](
+    semanticdbEnabled := true,
+    semanticdbVersion := scalafixSemanticdb.revision,
+    scalafixScalaBinaryVersion := CrossVersion.binaryScalaVersion(scalaVersion.value),
+    tlScalafixDependencies := Seq(
+      "com.github.liancheng" %% "organize-imports" % "0.6.0"
+    ),
+    scalafixDependencies ++= tlScalafixDependencies.value
+  )
+}

--- a/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
+++ b/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
@@ -16,11 +16,12 @@
 
 package org.typelevel.sbt
 
-import sbt._, Keys._
 import com.github.sbt.git.GitPlugin
 import com.github.sbt.git.SbtGit.git
-import org.typelevel.sbt.kernel.V
-import org.typelevel.sbt.kernel.GitHelper
+import org.typelevel.sbt.kernel.{GitHelper, V}
+import sbt._
+
+import Keys._
 
 object TypelevelSettingsPlugin extends AutoPlugin {
   override def trigger = allRequirements

--- a/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
+++ b/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
@@ -19,10 +19,7 @@ package org.typelevel.sbt
 import laika.ast.LengthUnit._
 import laika.ast._
 import laika.helium.Helium
-import laika.helium.config.Favicon
-import laika.helium.config.HeliumIcon
-import laika.helium.config.IconLink
-import laika.helium.config.ImageLink
+import laika.helium.config.{Favicon, HeliumIcon, IconLink, ImageLink}
 import laika.sbt.LaikaPlugin
 import laika.theme.ThemeProvider
 import mdoc.MdocPlugin

--- a/site/src/main/scala/org/typelevel/sbt/site/ThemeProviderOps.scala
+++ b/site/src/main/scala/org/typelevel/sbt/site/ThemeProviderOps.scala
@@ -20,8 +20,7 @@ import cats.effect.Sync
 import laika.bundle.ExtensionBundle
 import laika.factory.Format
 import laika.io.model.InputTree
-import laika.theme.Theme
-import laika.theme.ThemeProvider
+import laika.theme.{Theme, ThemeProvider}
 
 final class LaikaThemeProviderOps private[sbt] (provider: ThemeProvider) {
 

--- a/site/src/main/scala/org/typelevel/sbt/site/TypelevelHeliumExtensions.scala
+++ b/site/src/main/scala/org/typelevel/sbt/site/TypelevelHeliumExtensions.scala
@@ -16,8 +16,7 @@
 
 package org.typelevel.sbt.site
 
-import cats.effect.Resource
-import cats.effect.Sync
+import cats.effect.{Resource, Sync}
 import laika.ast.Path
 import laika.config.Config
 import laika.io.model.InputTree
@@ -25,9 +24,7 @@ import laika.markdown.github.GitHubFlavor
 import laika.parse.code.SyntaxHighlighting
 import laika.parse.code.languages.DottySyntax
 import laika.rewrite.DefaultTemplatePath
-import laika.theme.Theme
-import laika.theme.ThemeBuilder
-import laika.theme.ThemeProvider
+import laika.theme.{Theme, ThemeBuilder, ThemeProvider}
 
 import java.net.URL
 

--- a/sonatype-ci-release/src/main/scala/org/typelevel/sbt/TypelevelSonatypeCiReleasePlugin.scala
+++ b/sonatype-ci-release/src/main/scala/org/typelevel/sbt/TypelevelSonatypeCiReleasePlugin.scala
@@ -16,10 +16,9 @@
 
 package org.typelevel.sbt
 
-import sbt._
-import org.typelevel.sbt.gha.GenerativePlugin
-import org.typelevel.sbt.gha.GitHubActionsPlugin
 import org.typelevel.sbt.gha.GenerativePlugin.autoImport._
+import org.typelevel.sbt.gha.{GenerativePlugin, GitHubActionsPlugin}
+import sbt._
 
 object TypelevelSonatypeCiReleasePlugin extends AutoPlugin {
 

--- a/sonatype/src/main/scala/org/typelevel/sbt/TypelevelSonatypePlugin.scala
+++ b/sonatype/src/main/scala/org/typelevel/sbt/TypelevelSonatypePlugin.scala
@@ -16,9 +16,12 @@
 
 package org.typelevel.sbt
 
-import sbt._, Keys._
 import com.typesafe.tools.mima.plugin.MimaPlugin
-import xerial.sbt.Sonatype, Sonatype.autoImport._
+import sbt._
+import xerial.sbt.Sonatype
+
+import Keys._
+import Sonatype.autoImport._
 import TypelevelKernelPlugin.mkCommand
 
 object TypelevelSonatypePlugin extends AutoPlugin {

--- a/sonatype/src/main/scala/org/typelevel/sbt/TypelevelUnidocPlugin.scala
+++ b/sonatype/src/main/scala/org/typelevel/sbt/TypelevelUnidocPlugin.scala
@@ -16,9 +16,11 @@
 
 package org.typelevel.sbt
 
-import sbt._, Keys._
 import com.typesafe.tools.mima.plugin.MimaPlugin.autoImport._
+import sbt._
 import sbtunidoc.ScalaUnidocPlugin
+
+import Keys._
 
 object TypelevelUnidocPlugin extends AutoPlugin {
 

--- a/versioning/src/main/scala/org/typelevel/sbt/TypelevelVersioningPlugin.scala
+++ b/versioning/src/main/scala/org/typelevel/sbt/TypelevelVersioningPlugin.scala
@@ -16,13 +16,14 @@
 
 package org.typelevel.sbt
 
-import sbt._, Keys._
 import com.github.sbt.git.GitPlugin
 import com.github.sbt.git.SbtGit.git
-import org.typelevel.sbt.kernel.V
+import org.typelevel.sbt.kernel.{GitHelper, V}
+import sbt._
 
 import scala.util.Try
-import org.typelevel.sbt.kernel.GitHelper
+
+import Keys._
 
 object TypelevelVersioningPlugin extends AutoPlugin {
 


### PR DESCRIPTION
Currently includes only [liancheng/scalafix-organize-imports](https://github.com/liancheng/scalafix-organize-imports), could be used later to roll out [typelevel-scalafix](https://github.com/typelevel/typelevel-scalafix).

Unfortunately it's not totally straightforward to roll this out as a CI step - e.g. if we consider cats, there are currently some bincompat tricks in place that conflict with the simulacrum-scalafix generated code, so it's currently (deliberately) not in sync with its Scalafix migrations.
Unless we implemented some kind of "redirect" or "migrate" annotation to handle those cases in the simulacrum code by dispatching a deprecated ops method to its replacement, I don't think Github Actions part of this could be enabled in cats by default as it would always produce a diff.

Another concern is that enabling Scalafix in check mode could lead to build failures whenever a Scalafix rule produces code that is not correctly formatted according to `scalafmtCheckAll`. I have asked on the Scalameta Discord about whether it's possible to run Scalafmt on Scalafix output before running checks.