### PR TITLE
Make default CI steps togglable

### DIFF
--- a/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
@@ -29,23 +29,82 @@ object TypelevelCiPlugin extends AutoPlugin {
 
   object autoImport {
     def tlCrossRootProject: CrossRootProject = CrossRootProject()
+
+    lazy val tlCiHeaderCheck =
+      settingKey[Boolean]("Whether to do header check in CI (default: false)")
+    lazy val tlCiScalafmtCheck =
+      settingKey[Boolean]("Whether to do scalafmt check in CI (default: false)")
+    lazy val tlCiMimaBinaryIssueCheck =
+      settingKey[Boolean]("Whether to do MiMa binary issues check in CI (default: true)")
+    lazy val tlCiDocCheck =
+      settingKey[Boolean]("Whether to build API docs in CI (default: true)")
   }
 
+  import autoImport._
+
   override def buildSettings = Seq(
+    tlCiHeaderCheck := false,
+    tlCiScalafmtCheck := false,
+    tlCiMimaBinaryIssueCheck := true,
+    tlCiDocCheck := true,
     githubWorkflowPublishTargetBranches := Seq(),
-    githubWorkflowBuild := Seq(
-      WorkflowStep.Sbt(List("test"), name = Some("Test")),
-      WorkflowStep.Sbt(
-        List("mimaReportBinaryIssues"),
-        name = Some("Check binary compatibility"),
-        cond = Some(primaryJavaCond.value)
-      ),
-      WorkflowStep.Sbt(
-        List("doc"),
-        name = Some("Generate API documentation"),
-        cond = Some(primaryJavaCond.value)
+    githubWorkflowBuild := {
+
+      val style = (tlCiHeaderCheck.value, tlCiScalafmtCheck.value) match {
+        case (true, true) => // headers + formatting
+          List(
+            WorkflowStep.Sbt(
+              List("headerCheckAll", "scalafmtCheckAll", "project /", "scalafmtSbtCheck"),
+              name = Some("Check headers and formatting"),
+              cond = Some(primaryJavaCond.value)
+            )
+          )
+        case (true, false) => // headers
+          List(
+            WorkflowStep.Sbt(
+              List("headerCheckAll"),
+              name = Some("Check headers"),
+              cond = Some(primaryJavaCond.value)
+            )
+          )
+        case (false, true) => // formatting
+          List(
+            WorkflowStep.Sbt(
+              List("scalafmtCheckAll", "project /", "scalafmtSbtCheck"),
+              name = Some("Check formatting"),
+              cond = Some(primaryJavaCond.value)
+            )
+          )
+        case (false, false) => Nil // nada
+      }
+
+      val test = List(
+        WorkflowStep.Sbt(List("test"), name = Some("Test"))
       )
-    ),
+
+      val mima =
+        if (tlCiMimaBinaryIssueCheck.value)
+          List(
+            WorkflowStep.Sbt(
+              List("mimaReportBinaryIssues"),
+              name = Some("Check binary compatibility"),
+              cond = Some(primaryJavaCond.value)
+            ))
+        else Nil
+
+      val doc =
+        if (tlCiDocCheck.value)
+          List(
+            WorkflowStep.Sbt(
+              List("doc"),
+              name = Some("Generate API documentation"),
+              cond = Some(primaryJavaCond.value)
+            )
+          )
+        else Nil
+
+      style ++ test ++ mima ++ doc
+    },
     githubWorkflowJavaVersions := Seq(JavaSpec.temurin("8"))
   )
 

--- a/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
+++ b/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
@@ -41,6 +41,7 @@ object TypelevelPlugin extends AutoPlugin {
 
   import autoImport._
   import TypelevelKernelPlugin.mkCommand
+  import TypelevelCiPlugin.autoImport._
   import TypelevelSettingsPlugin.autoImport._
   import TypelevelSonatypeCiReleasePlugin.autoImport._
   import GenerativePlugin.autoImport._
@@ -62,6 +63,8 @@ object TypelevelPlugin extends AutoPlugin {
     },
     startYear := Some(java.time.YearMonth.now().getYear()),
     licenses += "Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0.txt"),
+    tlCiHeaderCheck := true,
+    tlCiScalafmtCheck := true,
     tlCiReleaseBranches := Seq("main"),
     Def.derive(tlFatalWarnings := (tlFatalWarningsInCi.value && githubIsWorkflowBuild.value)),
     githubWorkflowBuildMatrixExclusions ++= {
@@ -70,13 +73,6 @@ object TypelevelPlugin extends AutoPlugin {
         scala <- githubWorkflowScalaVersions.value.filterNot(_ == defaultScala)
         java <- githubWorkflowJavaVersions.value.tail // default java is head
       } yield MatrixExclude(Map("scala" -> scala, "java" -> java.render))
-    },
-    githubWorkflowBuild := {
-      WorkflowStep.Sbt(
-        List("headerCheckAll", "scalafmtCheckAll", "project /", "scalafmtSbtCheck"),
-        name = Some("Check headers and formatting"),
-        cond = Some(primaryJavaCond.value)
-      ) +: githubWorkflowBuild.value
     }
   ) ++ addCommandAlias(
     "prePR",


### PR DESCRIPTION
Closes https://github.com/typelevel/sbt-typelevel/issues/247.

This PR adds settings to the `TypelevelCiPlugin` to toggle various steps in the generated CI workflow.

This makes it easy for individual builds/projects to turn these steps on/off, so that a project can still get scalafmt checks for example even if they don't want header checks or scalac settings.

In sbt-typelevel v0.5.0 I will make all these false by default in the `TypelevelCiPlugin`, and enable them as appropriate in the `TypelevelCiReleasePlugin` and `TypelevelPlugin`. This will make it easier to use the `TypelevelCiPlugin` for non-publishing applications developed on GitHub.