### PR TITLE
Auto-populate developers w/ GH info

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ ThisBuild / tlBaseVersion := "0.4"
 ThisBuild / tlCiReleaseBranches := Seq("series/0.4")
 ThisBuild / tlSitePublishBranch := Some("series/0.4")
 ThisBuild / crossScalaVersions := Seq("2.12.15")
-ThisBuild / developers := List(
+ThisBuild / developers ++= List(
   tlGitHubDev("armanbilge", "Arman Bilge"),
   tlGitHubDev("rossabaker", "Ross A. Baker"),
   tlGitHubDev("ChristopherDavenport", "Christopher Davenport"),

--- a/github/src/main/scala/org/typelevel/sbt/TypelevelGitHubPlugin.scala
+++ b/github/src/main/scala/org/typelevel/sbt/TypelevelGitHubPlugin.scala
@@ -46,7 +46,21 @@ object TypelevelGitHubPlugin extends AutoPlugin {
         sLog.value.info(s"set scmInfo to https://github.com/$user/$repo")
         gitHubScmInfo(user, repo)
     },
-    homepage := homepage.value.orElse(scmInfo.value.map(_.browseUrl))
+    homepage := homepage.value.orElse(scmInfo.value.map(_.browseUrl)),
+    developers := {
+      gitHubUserRepo
+        .value
+        .toList
+        .map {
+          case (user, repo) =>
+            Developer(
+              user,
+              s"$repo contributors",
+              s"@$user",
+              url(s"https://github.com/$user/$repo/contributors")
+            )
+        }
+    }
   )
 
   private def gitHubScmInfo(user: String, repo: String) =


### PR DESCRIPTION
So turns out I have opinions about this :) closes https://github.com/typelevel/sbt-typelevel/issues/277.

It creates an entry like this:
```xml
<developer>
    <id>typelevel</id>
    <name>sbt-typelevel contributors</name>
    <url>https://github.com/typelevel/sbt-typelevel/contributors</url>
    <email>@typelevel</email>
</developer>
```

This is breaking for anyone setting developers in their build like `++=`, so it goes to 0.5.