### PR TITLE
Skip doc task if irrelevant

### DIFF
--- a/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
+++ b/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
@@ -53,8 +53,14 @@ object TypelevelKernelPlugin extends AutoPlugin {
         ()
       else (Test / test).value
     },
+    (Compile / doc) := {
+      if (tlSkipIrrelevantScalas.value && (Compile / doc / skip).value)
+        (Compile / doc / target).value
+      else (Compile / doc).value
+    },
     skipIfIrrelevant(compile),
     skipIfIrrelevant(test),
+    skipIfIrrelevant(doc),
     skipIfIrrelevant(publishLocal),
     skipIfIrrelevant(publish)
   )


### PR DESCRIPTION
Really hate how brittle this workaround is.

I wonder if a better strategy is to never have a "hole" in the matrix that requires tasks to be skipped. A project can always "compile" for Scala 3 with empty sources and no dependencies, you just don't want to _publish_ it maybe. So there needs to be a way to enable the `NoPublishPlugin` per scala version. Something to think about for 0.5.0.