### PR TITLE
Don't run CI on `update/*` branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ name: Continuous Integration
 
 on:
   pull_request:
-    branches: ['**']
+    branches: ['**', '!update/**']
   push:
-    branches: ['**']
+    branches: ['**', '!update/**']
     tags: [v*]
 
 env:

--- a/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
@@ -50,6 +50,7 @@ object TypelevelCiPlugin extends AutoPlugin {
     tlCiScalafixCheck := false,
     tlCiMimaBinaryIssueCheck := true,
     tlCiDocCheck := true,
+    githubWorkflowTargetBranches += "!update/**", // ignore steward branches
     githubWorkflowPublishTargetBranches := Seq(),
     githubWorkflowBuild := {
 


### PR DESCRIPTION
See https://github.com/typelevel/sbt-typelevel/issues/177#issuecomment-1146580184 for context.

Strategically named this branch `update/ignore-me` to see if it works right.