### PR TITLE
Don't run ci on `pr/**` branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ name: Continuous Integration
 
 on:
   pull_request:
-    branches: ['**', '!update/**']
+    branches: ['**', '!update/**', '!pr/**']
   push:
-    branches: ['**', '!update/**']
+    branches: ['**', '!update/**', '!pr/**']
     tags: [v*]
 
 env:

--- a/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
@@ -50,7 +50,10 @@ object TypelevelCiPlugin extends AutoPlugin {
     tlCiScalafixCheck := false,
     tlCiMimaBinaryIssueCheck := true,
     tlCiDocCheck := true,
-    githubWorkflowTargetBranches += "!update/**", // ignore steward branches
+    githubWorkflowTargetBranches ++= Seq(
+      "!update/**", // ignore steward branches
+      "!pr/**" // escape-hatch to disable ci on a branch
+    ),
     githubWorkflowPublishTargetBranches := Seq(),
     githubWorkflowBuild := {
 


### PR DESCRIPTION
Closes https://github.com/typelevel/sbt-typelevel/issues/177.

Same ideas as https://github.com/typelevel/sbt-typelevel/pull/291. If you don't want CI on a branch (most likely because it is going to become a PR) simply prefix it with `pr/`. Easy.