### PR TITLE
Add startYear to example build

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -49,6 +49,7 @@ ThisBuild / tlBaseVersion := "0.4" // your current series x.y
 
 ThisBuild / organization := "org.typelevel"
 ThisBuild / organizationName := "Typelevel"
+ThisBuild / startYear := Some(2022)
 ThisBuild / licenses := Seq(License.Apache2)
 ThisBuild / developers := List(
   // your GitHub handle and name


### PR DESCRIPTION
Following https://github.com/typelevel/typelevel.g8/pull/28