### PR TITLE
POC: publish the website to sonatype/maven 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,15 +89,15 @@ jobs:
         run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' doc
 
       - name: Make target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/series/0.4')
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/series/0.4' || github.ref == 'refs/heads/feature/site-artifact')
         run: mkdir -p github/target github-actions/target kernel/target versioning/target ci-release/target scalafix/target target .js/target mdocs/target site/target ci-signing/target mergify/target unidoc/target mima/target .jvm/target .native/target no-publish/target sonatype/target ci/target sonatype-ci-release/target core/target settings/target project/target
 
       - name: Compress target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/series/0.4')
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/series/0.4' || github.ref == 'refs/heads/feature/site-artifact')
         run: tar cf targets.tar github/target github-actions/target kernel/target versioning/target ci-release/target scalafix/target target .js/target mdocs/target site/target ci-signing/target mergify/target unidoc/target mima/target .jvm/target .native/target no-publish/target sonatype/target ci/target sonatype-ci-release/target core/target settings/target project/target
 
       - name: Upload target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/series/0.4')
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/series/0.4' || github.ref == 'refs/heads/feature/site-artifact')
         uses: actions/upload-artifact@v2
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.scala }}-${{ matrix.project }}
@@ -106,7 +106,7 @@ jobs:
   publish:
     name: Publish Artifacts
     needs: [build]
-    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/series/0.4')
+    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/series/0.4' || github.ref == 'refs/heads/feature/site-artifact')
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,7 @@ name := "sbt-typelevel"
 
 ThisBuild / tlBaseVersion := "0.4"
 ThisBuild / tlCiReleaseBranches := Seq("series/0.4")
+ThisBuild / tlCiReleaseBranches += "feature/site-artifact"
 ThisBuild / tlSitePublishBranch := Some("series/0.4")
 ThisBuild / crossScalaVersions := Seq("2.12.16")
 ThisBuild / developers := List(

--- a/build.sbt
+++ b/build.sbt
@@ -189,6 +189,7 @@ lazy val docs = project
   .in(file("mdocs"))
   .enablePlugins(TypelevelSitePlugin)
   .settings(
+    name := "sbt-typelevel-website",
     laikaConfig ~= { _.withRawContent },
     tlSiteApiPackage := Some("org.typelevel.sbt"),
     tlSiteRelatedProjects := Seq(

--- a/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
+++ b/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
@@ -109,8 +109,7 @@ object TypelevelSitePlugin extends AutoPlugin {
     Laika / sourceDirectories := Seq(mdocOut.value),
     laikaTheme := tlSiteHeliumConfig.value.build.extend(tlSiteHeliumExtensions.value),
     Compile / packageDoc / mappings := {
-      val _ = tlSite.value
-      (laikaSite / mappings).value
+      (laikaSite / mappings).dependsOn(tlSite).value
     },
     SettingKey[Set[ModuleID]]("mimaPreviousArtifacts") := Set.empty,
     mdocVariables := {

--- a/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
+++ b/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
@@ -112,6 +112,7 @@ object TypelevelSitePlugin extends AutoPlugin {
       tlSite.value: @nowarn("cat=other-pure-statement")
       (laikaSite / mappings).value
     },
+    SettingKey[Set[Nothing]]("mimaPreviousArtifacts") := Set.empty,
     mdocVariables := {
       mdocVariables.value ++
         Map(

--- a/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
+++ b/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
@@ -109,7 +109,7 @@ object TypelevelSitePlugin extends AutoPlugin {
     Laika / sourceDirectories := Seq(mdocOut.value),
     laikaTheme := tlSiteHeliumConfig.value.build.extend(tlSiteHeliumExtensions.value),
     Compile / packageDoc / mappings := {
-      val _ = tlSite.valueit 
+      val _ = tlSite.value
       (laikaSite / mappings).value
     },
     SettingKey[Set[ModuleID]]("mimaPreviousArtifacts") := Set.empty,

--- a/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
+++ b/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
@@ -109,7 +109,7 @@ object TypelevelSitePlugin extends AutoPlugin {
     Laika / sourceDirectories := Seq(mdocOut.value),
     laikaTheme := tlSiteHeliumConfig.value.build.extend(tlSiteHeliumExtensions.value),
     Compile / packageDoc / mappings := {
-      tlSite.value: @nowarn("cat=other-pure-statement")
+      val _ = tlSite.valueit 
       (laikaSite / mappings).value
     },
     SettingKey[Set[ModuleID]]("mimaPreviousArtifacts") := Set.empty,

--- a/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
+++ b/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
@@ -112,7 +112,7 @@ object TypelevelSitePlugin extends AutoPlugin {
       tlSite.value: @nowarn("cat=other-pure-statement")
       (laikaSite / mappings).value
     },
-    SettingKey[Set[Nothing]]("mimaPreviousArtifacts") := Set.empty,
+    SettingKey[Set[ModuleID]]("mimaPreviousArtifacts") := Set.empty,
     mdocVariables := {
       mdocVariables.value ++
         Map(

--- a/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
+++ b/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
@@ -109,7 +109,7 @@ object TypelevelSitePlugin extends AutoPlugin {
     Laika / sourceDirectories := Seq(mdocOut.value),
     laikaTheme := tlSiteHeliumConfig.value.build.extend(tlSiteHeliumExtensions.value),
     Compile / packageDoc / mappings := {
-      tlSite.value
+      tlSite.value: @nowarn("cat=other-pure-statement")
       (laikaSite / mappings).value
     },
     mdocVariables := {

--- a/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
+++ b/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
@@ -77,7 +77,7 @@ object TypelevelSitePlugin extends AutoPlugin {
   import TypelevelGitHubPlugin._
 
   override def requires =
-    MdocPlugin && LaikaPlugin && TypelevelGitHubPlugin && GenerativePlugin && NoPublishPlugin
+    MdocPlugin && LaikaPlugin && TypelevelGitHubPlugin && GenerativePlugin
 
   override def globalSettings = Seq(
     tlSiteApiModule := None
@@ -108,6 +108,10 @@ object TypelevelSitePlugin extends AutoPlugin {
     tlSitePreview := previewTask.value,
     Laika / sourceDirectories := Seq(mdocOut.value),
     laikaTheme := tlSiteHeliumConfig.value.build.extend(tlSiteHeliumExtensions.value),
+    Compile / packageDoc / mappings := {
+      tlSite.value
+      (laikaSite / mappings).value
+    },
     mdocVariables := {
       mdocVariables.value ++
         Map(


### PR DESCRIPTION
Another strategy for https://github.com/typelevel/sbt-typelevel/issues/100. /cc @rossabaker

The idea is simple, and inspired by the success we've had publishing unidocs. In this case, we package up the Laika-generated website as a Javadoc artifact and publish it. Then, stable versions can be browsed at javadoc.io (with their handy version-picker!) and snapshots via Sonatype's own hosting infrastructure, like so:

https://s01.oss.sonatype.org/service/local/repositories/snapshots/archive/org/typelevel/sbt-typelevel-website_2.12/0.4.12-20-fb939ca-SNAPSHOT/sbt-typelevel-website_2.12-0.4.12-20-fb939ca-SNAPSHOT-javadoc.jar/!/index.html

The motivation is that setting up and maintaining versioned documentation is hard, even with Laika's integrated support for this. It's a lot of overhead for smaller projects that probably have only one active version at a time, but want to keep old documentation available as well.

Now, we have a stable destination to host these old versions of the site. Meanwhile, the current, live version of the site can be hosted on GH pages.

Thoughts?