### PR TITLE
Add request_reviews and update Mergify actions

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,7 +8,7 @@
 pull_request_rules:
 - name: merge scala-steward's PRs
   conditions:
-  - author=scala-steward
+  - author=typelevel-steward[bot]
   - or:
     - body~=labels:.*early-semver-patch
     - body~=labels:.*early-semver-minor
@@ -168,3 +168,10 @@ pull_request_rules:
       add:
       - versioning
       remove: []
+- name: assign scala-steward's PRs for review
+  conditions:
+  - author=typelevel-steward[bot]
+  actions:
+    request_reviews:
+      users:
+      - armanbilge

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ ThisBuild / mergifyPrRules += MergifyPrRule(
   "assign scala-steward's PRs for review",
   List(MergifyCondition.Custom("author=typelevel-steward[bot]")),
   List(
-    MergifyAction.RequestReviews("armanbilge")
+    MergifyAction.RequestReviews.fromUsers("armanbilge")
   )
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -11,9 +11,18 @@ ThisBuild / developers := List(
   tlGitHubDev("djspiewak", "Daniel Spiewak")
 )
 
-ThisBuild / mergifyStewardConfig ~= { _.map(_.copy(mergeMinors = true)) }
+ThisBuild / mergifyStewardConfig ~= {
+  _.map(_.copy(mergeMinors = true, author = "typelevel-steward[bot]"))
+}
 ThisBuild / mergifySuccessConditions += MergifyCondition.Custom("#approved-reviews-by>=1")
 ThisBuild / mergifyLabelPaths += { "docs" -> file("docs") }
+ThisBuild / mergifyPrRules += MergifyPrRule(
+  "assign scala-steward's PRs for review",
+  List(MergifyCondition.Custom("author=typelevel-steward[bot]")),
+  List(
+    MergifyAction.RequestReviews("armanbilge")
+  )
+)
 
 ThisBuild / scalafixDependencies ++= Seq(
   "com.github.liancheng" %% "organize-imports" % "0.6.0"

--- a/mergify/src/main/scala/org/typelevel/sbt/mergify/MergifyAction.scala
+++ b/mergify/src/main/scala/org/typelevel/sbt/mergify/MergifyAction.scala
@@ -16,7 +16,7 @@
 
 package org.typelevel.sbt.mergify
 
-import io.circe.Encoder
+import io.circe._
 import io.circe.syntax._
 
 sealed abstract class MergifyAction {
@@ -29,6 +29,7 @@ object MergifyAction {
     case merge: Merge => merge.asJson
     case label: Label => label.asJson
     case requestReviews: RequestReviews => requestReviews.asJson
+    case Update => Update.asJson
     case _ => sys.error("should not happen")
   }
 
@@ -65,6 +66,12 @@ object MergifyAction {
   object RequestReviews {
     implicit def encoder: Encoder[RequestReviews] =
       Encoder.forProduct1("users")(_.users)
+  }
+
+  final case object Update extends MergifyAction {
+    override private[mergify] def name = "update"
+
+    implicit def encoder: Encoder[Update.type] = Encoder[JsonObject].contramap(_ => JsonObject.empty)
   }
 
   private[this] object Dummy extends MergifyAction

--- a/mergify/src/main/scala/org/typelevel/sbt/mergify/MergifyAction.scala
+++ b/mergify/src/main/scala/org/typelevel/sbt/mergify/MergifyAction.scala
@@ -78,28 +78,28 @@ object MergifyAction {
         randomCount: Option[Int] = randomCount): RequestReviews =
       new RequestReviews(users, teams, usersFromTeams, randomCount) {}
 
-    def andUsers(user: String, users: String*): RequestReviews =
+    def withUsers(user: String, users: String*): RequestReviews =
       copy(users = Unweighted(NonEmptyList.of(user, users: _*)).some)
 
-    def andUsers(user: (String, Int), users: (String, Int)*): RequestReviews =
+    def withUsers(user: (String, Int), users: (String, Int)*): RequestReviews =
       copy(users = Weighted(NonEmptyList.of(user, users: _*)).some)
 
-    def andTeams(team: String, teams: String*): RequestReviews =
+    def withTeams(team: String, teams: String*): RequestReviews =
       copy(teams = Unweighted(NonEmptyList.of(team, teams: _*)).some)
 
-    def andTeams(team: (String, Int), teams: (String, Int)*): RequestReviews =
+    def withTeams(team: (String, Int), teams: (String, Int)*): RequestReviews =
       copy(teams = Weighted(NonEmptyList.of(team, teams: _*)).some)
 
-    def andUsersFromTeams(team: String, teams: String*): RequestReviews =
+    def withUsersFromTeams(team: String, teams: String*): RequestReviews =
       copy(usersFromTeams = Unweighted(NonEmptyList.of(team, teams: _*)).some)
 
-    def andUsersFromTeams(team: (String, Int), teams: (String, Int)*): RequestReviews =
+    def withUsersFromTeams(team: (String, Int), teams: (String, Int)*): RequestReviews =
       copy(usersFromTeams = Weighted(NonEmptyList.of(team, teams: _*)).some)
 
     def withRandomCount(count: Int): RequestReviews =
       copy(randomCount = Option(count))
 
-    def andDevelopers(developers: List[Developer]): RequestReviews =
+    def withDevelopers(developers: List[Developer]): RequestReviews =
       copy(users = NonEmptyList.fromList(developers.map(_.id)).map(Unweighted))
   }
 

--- a/mergify/src/main/scala/org/typelevel/sbt/mergify/MergifyAction.scala
+++ b/mergify/src/main/scala/org/typelevel/sbt/mergify/MergifyAction.scala
@@ -16,10 +16,11 @@
 
 package org.typelevel.sbt.mergify
 
-import cats.data.*
-import cats.syntax.all.*
-import io.circe.*
-import io.circe.syntax.*
+import cats.data._
+import cats.syntax.all._
+import io.circe._
+import io.circe.syntax._
+import org.typelevel.sbt.mergify.MergifyAction.RequestReviews._
 import sbt.librarymanagement.Developer
 
 sealed abstract class MergifyAction {
@@ -62,51 +63,93 @@ object MergifyAction {
       }
   }
 
-  final class RequestReviews(
-      val users: Either[NonEmptyList[String], NonEmptyMap[String, Int]],
-      val randomCount: Option[Int])
+  class RequestReviews private (
+      private val users: Option[OptionallyWeighted],
+      private val teams: Option[OptionallyWeighted],
+      private val usersFromTeams: Option[OptionallyWeighted],
+      private val randomCount: Option[Int])
       extends MergifyAction {
     override private[mergify] def name = "request_reviews"
+
+    private def copy(
+        users: Option[OptionallyWeighted] = users,
+        teams: Option[OptionallyWeighted] = teams,
+        usersFromTeams: Option[OptionallyWeighted] = usersFromTeams,
+        randomCount: Option[Int] = randomCount): RequestReviews =
+      new RequestReviews(users, teams, usersFromTeams, randomCount) {}
+
+    def andUsers(user: String, users: String*): RequestReviews =
+      copy(users = Unweighted(NonEmptyList.of(user, users: _*)).some)
+
+    def andUsers(user: (String, Int), users: (String, Int)*): RequestReviews =
+      copy(users = Weighted(NonEmptyList.of(user, users: _*)).some)
+
+    def andTeams(team: String, teams: String*): RequestReviews =
+      copy(teams = Unweighted(NonEmptyList.of(team, teams: _*)).some)
+
+    def andTeams(team: (String, Int), teams: (String, Int)*): RequestReviews =
+      copy(teams = Weighted(NonEmptyList.of(team, teams: _*)).some)
+
+    def andUsersFromTeams(team: String, teams: String*): RequestReviews =
+      copy(usersFromTeams = Unweighted(NonEmptyList.of(team, teams: _*)).some)
+
+    def andUsersFromTeams(team: (String, Int), teams: (String, Int)*): RequestReviews =
+      copy(usersFromTeams = Weighted(NonEmptyList.of(team, teams: _*)).some)
+
+    def withRandomCount(count: Int): RequestReviews =
+      copy(randomCount = Option(count))
+
+    def andDevelopers(developers: List[Developer]): RequestReviews =
+      copy(users = NonEmptyList.fromList(developers.map(_.id)).map(Unweighted))
   }
 
   object RequestReviews {
-    def apply(user: String, users: String*) =
-      new RequestReviews(NonEmptyList.of(user, users: _*).asLeft, None)
-
-    def apply(weightedUser: (String, Int), weightedUsers: (String, Int)*) =
-      new RequestReviews(NonEmptyMap.of(weightedUser, weightedUsers: _*).asRight, None)
-
-    def apply(randomCount: Int, user: String, users: String*) =
-      new RequestReviews(NonEmptyList.of(user, users: _*).asLeft, Option(randomCount))
-
-    def apply(randomCount: Int, weightedUser: (String, Int), weightedUsers: (String, Int)*) =
-      new RequestReviews(
-        NonEmptyMap.of(weightedUser, weightedUsers: _*).asRight,
-        Option(randomCount)
-      )
+    def fromUsers(user: String, users: String*) =
+      new RequestReviews(Unweighted(NonEmptyList.of(user, users: _*)).some, None, None, None)
+    def fromUsers(user: (String, Int), users: (String, Int)*) =
+      new RequestReviews(Weighted(NonEmptyList.of(user, users: _*)).some, None, None, None)
+    def fromTeams(team: String, teams: String*) =
+      new RequestReviews(None, Unweighted(NonEmptyList.of(team, teams: _*)).some, None, None)
+    def fromTeams(team: (String, Int), teams: (String, Int)*) =
+      new RequestReviews(None, Weighted(NonEmptyList.of(team, teams: _*)).some, None, None)
+    def fromUsersOfTeams(team: String, teams: String*) =
+      new RequestReviews(None, None, Unweighted(NonEmptyList.of(team, teams: _*)).some, None)
+    def fromUsersOfTeams(team: (String, Int), teams: (String, Int)*) =
+      new RequestReviews(None, None, Weighted(NonEmptyList.of(team, teams: _*)).some, None)
 
     def apply(developers: List[Developer]) =
       new RequestReviews(
-        developers
-          .map(_.id)
-          .toNel
-          .getOrElse(throw new RuntimeException("developers must be non-empty"))
-          .asLeft,
+        Unweighted(
+          developers
+            .map(_.id)
+            .toNel
+            .getOrElse(throw new RuntimeException("developers must be non-empty"))
+        ).some,
+        None,
+        None,
         None)
 
-    def apply(developers: List[Developer], randomCount: Int) =
-      new RequestReviews(
-        developers
-          .map(_.id)
-          .toNel
-          .getOrElse(throw new RuntimeException("developers must be non-empty"))
-          .asLeft,
-        randomCount.some)
-
     implicit def encoder: Encoder[RequestReviews] =
-      Encoder.forProduct2("users", "random_count") { requestReviews =>
-        (requestReviews.users.fold(_.asJson, _.asJson), requestReviews.randomCount)
+      Encoder.forProduct4("users", "teams", "users_from_teams", "random_count") {
+        requestReviews =>
+          (
+            requestReviews.users,
+            requestReviews.teams,
+            requestReviews.usersFromTeams,
+            requestReviews.randomCount
+          )
       }
+
+    private sealed trait OptionallyWeighted
+    private case class Weighted(value: NonEmptyList[(String, Int)]) extends OptionallyWeighted
+    private case class Unweighted(value: NonEmptyList[String]) extends OptionallyWeighted
+
+    private object OptionallyWeighted {
+      implicit val encoder: Encoder[OptionallyWeighted] = {
+        case Weighted(value) => value.asJson
+        case Unweighted(value) => value.asJson
+      }
+    }
   }
 
   object Update extends MergifyAction {

--- a/mergify/src/main/scala/org/typelevel/sbt/mergify/MergifyAction.scala
+++ b/mergify/src/main/scala/org/typelevel/sbt/mergify/MergifyAction.scala
@@ -16,10 +16,11 @@
 
 package org.typelevel.sbt.mergify
 
-import cats.data._
-import cats.syntax.all._
-import io.circe._
-import io.circe.syntax._
+import cats.data.*
+import cats.syntax.all.*
+import io.circe.*
+import io.circe.syntax.*
+import sbt.librarymanagement.Developer
 
 sealed abstract class MergifyAction {
   private[mergify] def name = getClass.getSimpleName.toLowerCase
@@ -83,6 +84,24 @@ object MergifyAction {
         NonEmptyMap.of(weightedUser, weightedUsers: _*).asRight,
         Option(randomCount)
       )
+
+    def apply(developers: List[Developer]) =
+      new RequestReviews(
+        developers
+          .map(_.id)
+          .toNel
+          .getOrElse(throw new RuntimeException("developers must be non-empty"))
+          .asLeft,
+        None)
+
+    def apply(developers: List[Developer], randomCount: Int) =
+      new RequestReviews(
+        developers
+          .map(_.id)
+          .toNel
+          .getOrElse(throw new RuntimeException("developers must be non-empty"))
+          .asLeft,
+        randomCount.some)
 
     implicit def encoder: Encoder[RequestReviews] =
       Encoder.forProduct2("users", "random_count") { requestReviews =>

--- a/mergify/src/main/scala/org/typelevel/sbt/mergify/MergifyAction.scala
+++ b/mergify/src/main/scala/org/typelevel/sbt/mergify/MergifyAction.scala
@@ -28,6 +28,7 @@ object MergifyAction {
   implicit def encoder: Encoder[MergifyAction] = Encoder.instance {
     case merge: Merge => merge.asJson
     case label: Label => label.asJson
+    case requestReviews: RequestReviews => requestReviews.asJson
     case _ => sys.error("should not happen")
   }
 
@@ -55,6 +56,15 @@ object MergifyAction {
       Encoder.forProduct3("add", "remove", "remove_all") { (l: Label) =>
         (l.add, l.remove, l.removeAll)
       }
+  }
+
+  final case class RequestReviews(users: List[String] = Nil) extends MergifyAction {
+    override private[mergify] def name = "request_reviews"
+  }
+
+  object RequestReviews {
+    implicit def encoder: Encoder[RequestReviews] =
+      Encoder.forProduct1("users")(_.users)
   }
 
   private[this] object Dummy extends MergifyAction

--- a/mergify/src/main/scala/org/typelevel/sbt/mergify/MergifyAction.scala
+++ b/mergify/src/main/scala/org/typelevel/sbt/mergify/MergifyAction.scala
@@ -62,7 +62,7 @@ object MergifyAction {
   }
 
   final class RequestReviews(
-      val users: Either[Seq[String], Map[String, Int]],
+      val users: Either[NonEmptyList[String], NonEmptyMap[String, Int]],
       val randomCount: Option[Int])
       extends MergifyAction {
     override private[mergify] def name = "request_reviews"
@@ -70,16 +70,19 @@ object MergifyAction {
 
   object RequestReviews {
     def apply(user: String, users: String*) =
-      new RequestReviews((user :: users.toList).asLeft, None)
+      new RequestReviews(NonEmptyList.of(user, users: _*).asLeft, None)
 
     def apply(weightedUser: (String, Int), weightedUsers: (String, Int)*) =
-      new RequestReviews((weightedUser :: weightedUsers.toList).toMap.asRight, None)
+      new RequestReviews(NonEmptyMap.of(weightedUser, weightedUsers: _*).asRight, None)
 
-    def apply(users: NonEmptyList[String], randomCount: Int) =
-      new RequestReviews(users.toList.asLeft, Option(randomCount))
+    def apply(randomCount: Int, user: String, users: String*) =
+      new RequestReviews(NonEmptyList.of(user, users: _*).asLeft, Option(randomCount))
 
-    def apply(weightedUsers: NonEmptyMap[String, Int], randomCount: Int) =
-      new RequestReviews(weightedUsers.toSortedMap.asRight, Option(randomCount))
+    def apply(randomCount: Int, weightedUser: (String, Int), weightedUsers: (String, Int)*) =
+      new RequestReviews(
+        NonEmptyMap.of(weightedUser, weightedUsers: _*).asRight,
+        Option(randomCount)
+      )
 
     implicit def encoder: Encoder[RequestReviews] =
       Encoder.forProduct2("users", "random_count") { requestReviews =>


### PR DESCRIPTION
Most of our OSS projects use the `request_reviews` and `update` Mergify actions, which aren't supported yet. e.g. https://github.com/Dwolla/fs2-pgp/blob/main/.mergify.yml

We have also typically used merge queues instead of merging directly, but I'm not sure how important that is. I remember we switched from "strict" merges when [Mergify deprecated them](https://blog.mergify.com/strict-mode-deprecation/), but maybe that was overkill for our needs. I'll play with it and see; we can always add that in a future PR.