### PR TITLE
Only download artifacts for primary OS/JDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,16 +189,6 @@ jobs:
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (2.12.16, rootJVM)
-        uses: actions/download-artifact@v2
-        with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.16-rootJVM
-
-      - name: Inflate target directories (2.12.16, rootJVM)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
-
       - name: Import signing key
         if: env.PGP_SECRET != '' && env.PGP_PASSPHRASE == ''
         run: echo $PGP_SECRET | base64 -di | gpg --import

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.12.16]
-        java: [temurin@8]
+        java: [temurin@8, temurin@17]
         project: [rootJVM]
     runs-on: ${{ matrix.os }}
     steps:
@@ -53,6 +53,22 @@ jobs:
           distribution: jdkfile
           java-version: 8
           jdkFile: ${{ steps.download-java-temurin-8.outputs.jdkFile }}
+
+      - name: Download Java (temurin@17)
+        id: download-java-temurin-17
+        if: matrix.java == 'temurin@17'
+        uses: typelevel/download-java@v1
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Java (temurin@17)
+        if: matrix.java == 'temurin@17'
+        uses: actions/setup-java@v2
+        with:
+          distribution: jdkfile
+          java-version: 17
+          jdkFile: ${{ steps.download-java-temurin-17.outputs.jdkFile }}
 
       - name: Cache sbt
         uses: actions/cache@v2
@@ -135,6 +151,22 @@ jobs:
           java-version: 8
           jdkFile: ${{ steps.download-java-temurin-8.outputs.jdkFile }}
 
+      - name: Download Java (temurin@17)
+        id: download-java-temurin-17
+        if: matrix.java == 'temurin@17'
+        uses: typelevel/download-java@v1
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Java (temurin@17)
+        if: matrix.java == 'temurin@17'
+        uses: actions/setup-java@v2
+        with:
+          distribution: jdkfile
+          java-version: 17
+          jdkFile: ${{ steps.download-java-temurin-17.outputs.jdkFile }}
+
       - name: Cache sbt
         uses: actions/cache@v2
         with:
@@ -146,6 +178,16 @@ jobs:
             ~/AppData/Local/Coursier/Cache/v1
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+
+      - name: Download target directories (2.12.16, rootJVM)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.16-rootJVM
+
+      - name: Inflate target directories (2.12.16, rootJVM)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
 
       - name: Download target directories (2.12.16, rootJVM)
         uses: actions/download-artifact@v2
@@ -200,6 +242,22 @@ jobs:
           distribution: jdkfile
           java-version: 8
           jdkFile: ${{ steps.download-java-temurin-8.outputs.jdkFile }}
+
+      - name: Download Java (temurin@17)
+        id: download-java-temurin-17
+        if: matrix.java == 'temurin@17'
+        uses: typelevel/download-java@v1
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Java (temurin@17)
+        if: matrix.java == 'temurin@17'
+        uses: actions/setup-java@v2
+        with:
+          distribution: jdkfile
+          java-version: 17
+          jdkFile: ${{ steps.download-java-temurin-17.outputs.jdkFile }}
 
       - name: Cache sbt
         uses: actions/cache@v2

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -13,6 +13,7 @@ pull_request_rules:
     - body~=labels:.*early-semver-patch
     - body~=labels:.*early-semver-minor
   - status-success=Build and Test (ubuntu-latest, 2.12.16, temurin@8, rootJVM)
+  - status-success=Build and Test (ubuntu-latest, 2.12.16, temurin@17, rootJVM)
   - '#approved-reviews-by>=1'
   actions:
     merge: {}

--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,8 @@ ThisBuild / developers := List(
   tlGitHubDev("djspiewak", "Daniel Spiewak")
 )
 
+ThisBuild / githubWorkflowJavaVersions += JavaSpec.temurin("17")
+
 ThisBuild / mergifyStewardConfig ~= {
   _.map(_.copy(mergeMinors = true, author = "typelevel-steward[bot]"))
 }

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativePlugin.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativePlugin.scala
@@ -615,9 +615,9 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}
       }
 
       val keys = "scala" :: additions.keys.toList.sorted
-      val oses = githubWorkflowOSes.value.toList
+      val oses = githubWorkflowOSes.value.toList.take(1)
       val scalas = githubWorkflowScalaVersions.value.toList
-      val javas = githubWorkflowJavaVersions.value.toList
+      val javas = githubWorkflowJavaVersions.value.toList.take(1)
       val exclusions = githubWorkflowBuildMatrixExclusions.value.toList
 
       // we build the list of artifacts, by iterating over all combinations of keys


### PR DESCRIPTION
Fixes https://github.com/typelevel/sbt-typelevel/issues/327.

This also adds a JDK 17 job to CI as part of the replication. I think this is a good addition anyway.