### PR TITLE
Add dependency submission job to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,68 @@ jobs:
           SONATYPE_CREDENTIAL_HOST: ${{ secrets.SONATYPE_CREDENTIAL_HOST }}
         run: sbt '++${{ matrix.scala }}' tlRelease
 
+  dependency-submission:
+    name: Submit Dependencies
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        scala: [2.12.16]
+        java: [temurin@8]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Download Java (temurin@8)
+        id: download-java-temurin-8
+        if: matrix.java == 'temurin@8'
+        uses: typelevel/download-java@v2
+        with:
+          distribution: temurin
+          java-version: 8
+
+      - name: Setup Java (temurin@8)
+        if: matrix.java == 'temurin@8'
+        uses: actions/setup-java@v3
+        with:
+          distribution: jdkfile
+          java-version: 8
+          jdkFile: ${{ steps.download-java-temurin-8.outputs.jdkFile }}
+
+      - name: Download Java (temurin@17)
+        id: download-java-temurin-17
+        if: matrix.java == 'temurin@17'
+        uses: typelevel/download-java@v2
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Java (temurin@17)
+        if: matrix.java == 'temurin@17'
+        uses: actions/setup-java@v3
+        with:
+          distribution: jdkfile
+          java-version: 17
+          jdkFile: ${{ steps.download-java-temurin-17.outputs.jdkFile }}
+
+      - name: Cache sbt
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2/cache
+            ~/.coursier/cache/v1
+            ~/.cache/coursier/v1
+            ~/AppData/Local/Coursier/Cache/v1
+            ~/Library/Caches/Coursier/v1
+          key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+
+      - name: Submit Dependencies
+        if: github.event_name != 'pull_request'
+        uses: scalacenter/sbt-dependency-submission@v2
+
   site:
     name: Generate Site
     strategy:

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/WorkflowStep.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/WorkflowStep.scala
@@ -84,6 +84,12 @@ object WorkflowStep {
   val Tmate: WorkflowStep =
     Use(UseRef.Public("mxschmitt", "action-tmate", "v3"), name = Some("Setup tmate session"))
 
+  val DependencySubmission: WorkflowStep =
+    Use(
+      UseRef.Public("scalacenter", "sbt-dependency-submission", "v2"),
+      name = Some("Submit Dependencies")
+    )
+
   def ComputeVar(name: String, cmd: String): WorkflowStep =
     Run(
       List("echo \"" + name + "=$(" + cmd + ")\" >> $GITHUB_ENV"),

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/WorkflowStep.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/WorkflowStep.scala
@@ -21,6 +21,11 @@ sealed trait WorkflowStep extends Product with Serializable {
   def name: Option[String]
   def cond: Option[String]
   def env: Map[String, String]
+
+  def withId(id: Option[String]): WorkflowStep
+  def withName(name: Option[String]): WorkflowStep
+  def withCond(cond: Option[String]): WorkflowStep
+  def withEnv(env: Map[String, String]): WorkflowStep
 }
 
 object WorkflowStep {
@@ -96,7 +101,13 @@ object WorkflowStep {
       cond: Option[String] = None,
       env: Map[String, String] = Map(),
       params: Map[String, String] = Map())
-      extends WorkflowStep
+      extends WorkflowStep {
+    def withId(id: Option[String]) = copy(id = id)
+    def withName(name: Option[String]) = copy(name = name)
+    def withCond(cond: Option[String]) = copy(cond = cond)
+    def withEnv(env: Map[String, String]) = copy(env = env)
+  }
+
   final case class Sbt(
       commands: List[String],
       id: Option[String] = None,
@@ -104,7 +115,13 @@ object WorkflowStep {
       cond: Option[String] = None,
       env: Map[String, String] = Map(),
       params: Map[String, String] = Map())
-      extends WorkflowStep
+      extends WorkflowStep {
+    def withId(id: Option[String]) = copy(id = id)
+    def withName(name: Option[String]) = copy(name = name)
+    def withCond(cond: Option[String]) = copy(cond = cond)
+    def withEnv(env: Map[String, String]) = copy(env = env)
+  }
+
   final case class Use(
       ref: UseRef,
       params: Map[String, String] = Map(),
@@ -112,5 +129,10 @@ object WorkflowStep {
       name: Option[String] = None,
       cond: Option[String] = None,
       env: Map[String, String] = Map())
-      extends WorkflowStep
+      extends WorkflowStep {
+    def withId(id: Option[String]) = copy(id = id)
+    def withName(name: Option[String]) = copy(name = name)
+    def withCond(cond: Option[String]) = copy(cond = cond)
+    def withEnv(env: Map[String, String]) = copy(env = env)
+  }
 }


### PR DESCRIPTION
Closes https://github.com/typelevel/sbt-typelevel/issues/326.

This adds a job that submits the projects dependencies to GitHub via
https://github.com/scalacenter/sbt-dependency-submission

Results should go here:
https://github.com/typelevel/sbt-typelevel/network/dependencies

Annoyingly I don't think we'll be able to see any results yet. I've targeted this at the `main` branch since I'm not sure yet how stable the action is, but GitHub only cares about the default branch which is `series/0.4`.