### PR TITLE
Tune Scala compiler warnings

### DIFF
--- a/kernel/src/main/scala/org/typelevel/sbt/kernel/V.scala
+++ b/kernel/src/main/scala/org/typelevel/sbt/kernel/V.scala
@@ -43,8 +43,8 @@ private[sbt] final case class V(
     if (y != 0) return y
     (this.patch, that.patch) match {
       case (None, None) => 0
-      case (None, Some(patch)) => 1
-      case (Some(patch), None) => -1
+      case (None, Some(_)) => 1
+      case (Some(_), None) => -1
       case (Some(thisPatch), Some(thatPatch)) =>
         val z = thisPatch.compare(thatPatch)
         if (z != 0) return z

--- a/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
+++ b/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
@@ -80,22 +80,25 @@ object TypelevelSettingsPlugin extends AutoPlugin {
       }
     },
     scalacOptions ++= {
-      val warningsNsc = Seq("-Xlint", "-Ywarn-dead-code")
+      val warningsNsc = Seq(
+        "-Xlint",
+        "-Ywarn-dead-code"
+      )
 
-      val warnings211 =
-        Seq("-Ywarn-numeric-widen") // In 2.10 this produces a some strange spurious error
+      val warnings211 = Seq(
+        "-Ywarn-numeric-widen" // In 2.10 this produces a some strange spurious error
+      )
 
       val removed212 = Set(
         "-Xlint"
       )
       val warnings212 = Seq(
-        "-Xlint:_,-unused",
-        "-Ywarn-unused:_,-nowarn" // '-nowarn' because 2.13 can detect more unused cases than 2.12
+        "-Xlint:_,-unused", // "unused" provided by '-Ywarn-unused'
+        "-Ywarn-unused:_,-nowarn,-privates" // '-nowarn' because 2.13 can detect more unused cases than 2.12
       )
 
       val removed213 = Set(
-        "-Xlint:_,-unused",
-        "-Ywarn-unused:_,-nowarn", // mostly superseded by "-Wunused"
+        "-Ywarn-unused:_,-nowarn,-privates", // mostly superseded by "-Wunused"
         "-Ywarn-dead-code", // superseded by "-Wdead-code"
         "-Ywarn-numeric-widen" // superseded by "-Wnumeric-widen"
       )
@@ -104,8 +107,7 @@ object TypelevelSettingsPlugin extends AutoPlugin {
         "-Wextra-implicit",
         "-Wnumeric-widen",
         "-Wunused", // all choices are enabled by default
-        "-Wvalue-discard",
-        "-Xlint:deprecation"
+        "-Wvalue-discard"
       )
 
       val warningsDotty = Seq.empty

--- a/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
+++ b/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
@@ -115,9 +115,10 @@ object TypelevelSettingsPlugin extends AutoPlugin {
         "-Wunused", // all choices are enabled by default
         "-Wvalue-discard",
         // Tune '-Xlint':
-        // - remove 'unused' because it is configured by '-Wunused'
         // - remove 'implicit-recursion' due to backward incompatibility with 2.12
-        "-Xlint:_,-unused,-implicit-recursion"
+        // - remove 'recurse-with-default' due to backward incompatibility with 2.12
+        // - remove 'unused' because it is configured by '-Wunused'
+        "-Xlint:_,-implicit-recursion,-recurse-with-default,-unused"
       )
 
       val warningsDotty = Seq.empty

--- a/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
+++ b/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
@@ -93,11 +93,17 @@ object TypelevelSettingsPlugin extends AutoPlugin {
         "-Xlint"
       )
       val warnings212 = Seq(
-        "-Xlint:_,-unused", // "unused" provided by '-Ywarn-unused'
-        "-Ywarn-unused:_,-nowarn,-privates" // '-nowarn' because 2.13 can detect more unused cases than 2.12
+        // Tune '-Xlint':
+        // - remove 'unused' because it is configured by '-Ywarn-unused'
+        "-Xlint:_,-unused",
+        // Tune '-Ywarn-unused':
+        // - remove 'nowarn' because 2.13 can detect more unused cases than 2.12
+        // - remove 'privates' because 2.12 can incorrectly detect some private objects as unused
+        "-Ywarn-unused:_,-nowarn,-privates"
       )
 
       val removed213 = Set(
+        "-Xlint:_,-unused", // reconfigured for 2.13
         "-Ywarn-unused:_,-nowarn,-privates", // mostly superseded by "-Wunused"
         "-Ywarn-dead-code", // superseded by "-Wdead-code"
         "-Ywarn-numeric-widen" // superseded by "-Wnumeric-widen"
@@ -107,7 +113,11 @@ object TypelevelSettingsPlugin extends AutoPlugin {
         "-Wextra-implicit",
         "-Wnumeric-widen",
         "-Wunused", // all choices are enabled by default
-        "-Wvalue-discard"
+        "-Wvalue-discard",
+        // Tune '-Xlint':
+        // - remove 'unused' because it is configured by '-Wunused'
+        // - remove 'implicit-recursion' due to backward incompatibility with 2.12
+        "-Xlint:_,-unused,-implicit-recursion"
       )
 
       val warningsDotty = Seq.empty

--- a/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
+++ b/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
@@ -85,10 +85,17 @@ object TypelevelSettingsPlugin extends AutoPlugin {
       val warnings211 =
         Seq("-Ywarn-numeric-widen") // In 2.10 this produces a some strange spurious error
 
-      val warnings212 = Seq.empty[String]
+      val removed212 = Set(
+        "-Xlint"
+      )
+      val warnings212 = Seq(
+        "-Xlint:_,-unused",
+        "-Ywarn-unused:_,-nowarn" // '-nowarn' because 2.13 can detect more unused cases than 2.12
+      )
 
       val removed213 = Set(
-        "-Xlint",
+        "-Xlint:_,-unused",
+        "-Ywarn-unused:_,-nowarn", // mostly superseded by "-Wunused"
         "-Ywarn-dead-code", // superseded by "-Wdead-code"
         "-Ywarn-numeric-widen" // superseded by "-Wnumeric-widen"
       )
@@ -108,10 +115,11 @@ object TypelevelSettingsPlugin extends AutoPlugin {
           warningsDotty
 
         case V(V(2, minor, _, _)) if minor >= 13 =>
-          (warnings211 ++ warnings212 ++ warnings213 ++ warningsNsc).filterNot(removed213)
+          (warnings211 ++ warnings212 ++ warnings213 ++ warningsNsc)
+            .filterNot(removed212 ++ removed213)
 
         case V(V(2, minor, _, _)) if minor >= 12 =>
-          warnings211 ++ warnings212 ++ warningsNsc
+          (warnings211 ++ warnings212 ++ warningsNsc).filterNot(removed212)
 
         case V(V(2, minor, _, _)) if minor >= 11 =>
           warnings211 ++ warningsNsc


### PR DESCRIPTION
The intent is to keep as many warnings as possible by still preserving backward compatibility between Scala 2.12 and 2.13 series (which is not always possible though).

For more details see a discussion in typelevel/cats-effect#3104.
