### PR TITLE
Fallback to apiURL if javadocioUrl does not exist

### DIFF
--- a/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
+++ b/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
@@ -138,8 +138,12 @@ object TypelevelSitePlugin extends AutoPlugin {
         val p = tlSiteApiPackage.value.fold("")(_.replace('.', '/') + "/index.html")
         url(s"https://www.javadoc.io/doc/$o/$n/$v/$p")
       }
+      lazy val fallbackUrl = for {
+        moduleId <- (ThisProject / tlSiteApiModule).value
+        apiURL <- moduleId.extraAttributes.get("e:info.apiURL")
+      } yield url(apiURL)
 
-      tlSiteApiUrl.value.orElse(javadocioUrl)
+      tlSiteApiUrl.value.orElse(javadocioUrl).orElse(fallbackUrl)
     },
     tlSiteHeliumConfig := {
       Helium


### PR DESCRIPTION
Of note, this will yield a URL that does not exist when:
- You run this on a dirty git workspace and thus have a timestamp as part of your snapshot
- You run this on a commit that has not had a snapshot published