### PR TITLE
Use workflow OSes for publish job

### DIFF
--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativePlugin.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativePlugin.scala
@@ -713,6 +713,7 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}
             githubWorkflowPublish.value.toList :::
             githubWorkflowPublishPostamble.value.toList,
           cond = Some(publicationCond.value),
+          oses = githubWorkflowOSes.value.toList.take(1),
           scalas = List(scalaVersion.value),
           javas = List(githubWorkflowJavaVersions.value.head),
           needs = List("build")


### PR DESCRIPTION
This came up in https://github.com/http4s/http4s-curl/pull/8 where I used explicitly named ubuntu versions instead of the usual `ubuntu-latest`. Then the publish job was no longer matching.