### PR TITLE
Do not use deprecated `-target` option on 2.13.9+

### DIFF
--- a/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
+++ b/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
@@ -227,8 +227,11 @@ object TypelevelSettingsPlugin extends AutoPlugin {
         case V(V(2, 12, Some(build), _)) if build >= 5 =>
           releaseOption ++ oldTargetOption
 
-        case V(V(2, 13, _, _)) =>
+        case V(V(2, 13, Some(build), _)) if build <= 8 =>
           releaseOption ++ newTargetOption
+
+        case V(V(2, 13, Some(build), _)) if build >= 9 =>
+          releaseOption
 
         case V(V(3, _, _, _)) =>
           releaseOption


### PR DESCRIPTION
Fixes this error, seen in builds using the `tlJdkRelease` option with Scala 2.13.9.

```
[error] -target is deprecated: Use -release instead to compile against the correct platform API.
```

Relevant PR:
- https://github.com/scala/scala/pull/9982