### PR TITLE
add a space to the Scala version selector command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,22 +87,22 @@ jobs:
 
       - name: Check headers and formatting
         if: matrix.java == 'temurin@8'
-        run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' headerCheckAll scalafmtCheckAll 'project /' scalafmtSbtCheck
+        run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' headerCheckAll scalafmtCheckAll 'project /' scalafmtSbtCheck
 
       - name: Test
-        run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' test
+        run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' test
 
       - name: Check scalafix lints
         if: matrix.java == 'temurin@8'
-        run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' 'scalafixAll --check'
+        run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' 'scalafixAll --check'
 
       - name: Check binary compatibility
         if: matrix.java == 'temurin@8'
-        run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' mimaReportBinaryIssues
+        run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' mimaReportBinaryIssues
 
       - name: Generate API documentation
         if: matrix.java == 'temurin@8'
-        run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' doc
+        run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' doc
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/series/0.4')
@@ -201,7 +201,7 @@ jobs:
           (echo "$PGP_PASSPHRASE"; echo; echo) | gpg --command-fd 0 --pinentry-mode loopback --change-passphrase $(gpg --list-secret-keys --with-colons 2> /dev/null | grep '^sec:' | cut --delimiter ':' --fields 5 | tail -n 1)
 
       - name: Publish
-        run: sbt '++${{ matrix.scala }}' tlRelease
+        run: sbt '++ ${{ matrix.scala }}' tlRelease
 
   site:
     name: Generate Site
@@ -262,7 +262,7 @@ jobs:
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
       - name: Generate site
-        run: sbt '++${{ matrix.scala }}' docs/tlSite
+        run: sbt '++ ${{ matrix.scala }}' docs/tlSite
 
       - name: Publish site
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/series/0.4'

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativeKeys.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativeKeys.scala
@@ -58,7 +58,7 @@ trait GenerativeKeys {
     "A list of steps to insert after comping and testing but before the end of the build job (default: [])")
   lazy val githubWorkflowBuildSbtStepPreamble =
     settingKey[Seq[String]](
-      s"Commands automatically prepended to a WorkflowStep.Sbt (default: ['++$${{ matrix.scala }}'])")
+      s"Commands automatically prepended to a WorkflowStep.Sbt (default: ['++ $${{ matrix.scala }}'])")
   lazy val githubWorkflowBuild = settingKey[Seq[WorkflowStep]](
     "A sequence of workflow steps which compile and test the project (default: [Sbt(List(\"test\"))])")
 

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativePlugin.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativePlugin.scala
@@ -516,7 +516,7 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}
     githubWorkflowBuildRunsOnExtraLabels := Seq(),
     githubWorkflowBuildPreamble := Seq(),
     githubWorkflowBuildPostamble := Seq(),
-    githubWorkflowBuildSbtStepPreamble := Seq(s"++$${{ matrix.scala }}"),
+    githubWorkflowBuildSbtStepPreamble := Seq(s"++ $${{ matrix.scala }}"),
     githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("test"), name = Some("Build project"))),
     githubWorkflowPublishPreamble := Seq(),
     githubWorkflowPublishPostamble := Seq(),

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/WorkflowJob.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/WorkflowJob.scala
@@ -20,7 +20,7 @@ final case class WorkflowJob(
     id: String,
     name: String,
     steps: List[WorkflowStep],
-    sbtStepPreamble: List[String] = List(s"++$${{ matrix.scala }}"),
+    sbtStepPreamble: List[String] = List(s"++ $${{ matrix.scala }}"),
     cond: Option[String] = None,
     env: Map[String, String] = Map(),
     oses: List[String] = List("ubuntu-latest"),


### PR DESCRIPTION
Using `sbt '++2.13' test` works, but `sbt '++3' test` does not. However, both `sbt '++ 2.13' test` and `sbt '++ 3' test` work, and the space is included in the [sbt documentation](https://www.scala-sbt.org/1.x/docs/Cross-Build.html#Switching+Scala+version).