### PR TITLE
Use `hostedApiUrl` as fallback for `apiURL`

### DIFF
--- a/sonatype/src/main/scala/org/typelevel/sbt/TypelevelSonatypePlugin.scala
+++ b/sonatype/src/main/scala/org/typelevel/sbt/TypelevelSonatypePlugin.scala
@@ -65,7 +65,7 @@ object TypelevelSonatypePlugin extends AutoPlugin {
           "s01.oss.sonatype.org"
       }
     },
-    apiURL := apiURL.value.orElse(javadocioUrl.value)
+    apiURL := apiURL.value.orElse(hostedApiUrl.value)
   )
 
   private[sbt] lazy val hostedApiUrl =


### PR DESCRIPTION
I think I forgot to update this in https://github.com/typelevel/sbt-typelevel/pull/284.