### PR TITLE
Bump actions to Node 16 versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -48,7 +48,7 @@ jobs:
 
       - name: Setup Java (temurin@8)
         if: matrix.java == 'temurin@8'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: jdkfile
           java-version: 8
@@ -64,14 +64,14 @@ jobs:
 
       - name: Setup Java (temurin@17)
         if: matrix.java == 'temurin@17'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: jdkfile
           java-version: 17
           jdkFile: ${{ steps.download-java-temurin-17.outputs.jdkFile }}
 
       - name: Cache sbt
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.sbt
@@ -131,7 +131,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -145,7 +145,7 @@ jobs:
 
       - name: Setup Java (temurin@8)
         if: matrix.java == 'temurin@8'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: jdkfile
           java-version: 8
@@ -161,14 +161,14 @@ jobs:
 
       - name: Setup Java (temurin@17)
         if: matrix.java == 'temurin@17'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: jdkfile
           java-version: 17
           jdkFile: ${{ steps.download-java-temurin-17.outputs.jdkFile }}
 
       - name: Cache sbt
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.sbt
@@ -213,7 +213,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -227,7 +227,7 @@ jobs:
 
       - name: Setup Java (temurin@8)
         if: matrix.java == 'temurin@8'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: jdkfile
           java-version: 8
@@ -243,14 +243,14 @@ jobs:
 
       - name: Setup Java (temurin@17)
         if: matrix.java == 'temurin@17'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: jdkfile
           java-version: 17
           jdkFile: ${{ steps.download-java-temurin-17.outputs.jdkFile }}
 
       - name: Cache sbt
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.sbt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Download Java (temurin@8)
         id: download-java-temurin-8
         if: matrix.java == 'temurin@8'
-        uses: typelevel/download-java@v1
+        uses: typelevel/download-java@v2
         with:
           distribution: temurin
           java-version: 8
@@ -57,7 +57,7 @@ jobs:
       - name: Download Java (temurin@17)
         id: download-java-temurin-17
         if: matrix.java == 'temurin@17'
-        uses: typelevel/download-java@v1
+        uses: typelevel/download-java@v2
         with:
           distribution: temurin
           java-version: 17
@@ -114,7 +114,7 @@ jobs:
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/series/0.4')
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.scala }}-${{ matrix.project }}
           path: targets.tar
@@ -138,7 +138,7 @@ jobs:
       - name: Download Java (temurin@8)
         id: download-java-temurin-8
         if: matrix.java == 'temurin@8'
-        uses: typelevel/download-java@v1
+        uses: typelevel/download-java@v2
         with:
           distribution: temurin
           java-version: 8
@@ -154,7 +154,7 @@ jobs:
       - name: Download Java (temurin@17)
         id: download-java-temurin-17
         if: matrix.java == 'temurin@17'
-        uses: typelevel/download-java@v1
+        uses: typelevel/download-java@v2
         with:
           distribution: temurin
           java-version: 17
@@ -180,7 +180,7 @@ jobs:
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
       - name: Download target directories (2.12.17, rootJVM)
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.17-rootJVM
 
@@ -220,7 +220,7 @@ jobs:
       - name: Download Java (temurin@8)
         id: download-java-temurin-8
         if: matrix.java == 'temurin@8'
-        uses: typelevel/download-java@v1
+        uses: typelevel/download-java@v2
         with:
           distribution: temurin
           java-version: 8
@@ -236,7 +236,7 @@ jobs:
       - name: Download Java (temurin@17)
         id: download-java-temurin-17
         if: matrix.java == 'temurin@17'
-        uses: typelevel/download-java@v1
+        uses: typelevel/download-java@v2
         with:
           distribution: temurin
           java-version: 17
@@ -266,7 +266,7 @@ jobs:
 
       - name: Publish site
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/series/0.4'
-        uses: peaceiris/actions-gh-pages@v3.8.0
+        uses: peaceiris/actions-gh-pages@v3.9.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: mdocs/target/docs/site

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativePlugin.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativePlugin.scala
@@ -662,7 +662,7 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}
 
       Seq(
         WorkflowStep.Use(
-          UseRef.Public("actions", "cache", "v2"),
+          UseRef.Public("actions", "cache", "v3"),
           name = Some("Cache sbt"),
           params = Map(
             "path" -> Seq(

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativePlugin.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativePlugin.scala
@@ -592,7 +592,7 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}
           (List("os", "java", "scala") ::: keys).map(k => s"$${{ matrix.$k }}").mkString("-")
 
         val upload = WorkflowStep.Use(
-          UseRef.Public("actions", "upload-artifact", "v2"),
+          UseRef.Public("actions", "upload-artifact", "v3"),
           name = Some(s"Upload target directories"),
           params = Map("name" -> s"target-$artifactId", "path" -> "targets.tar"),
           cond = Some(publicationCond.value)
@@ -639,7 +639,7 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}
           val pretty = v.mkString(", ")
 
           val download = WorkflowStep.Use(
-            UseRef.Public("actions", "download-artifact", "v2"),
+            UseRef.Public("actions", "download-artifact", "v3"),
             name = Some(s"Download target directories ($pretty)"),
             params =
               Map("name" -> s"target-$${{ matrix.os }}-$${{ matrix.java }}-${v.mkString("-")}")

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/WorkflowStep.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/WorkflowStep.scala
@@ -26,12 +26,12 @@ sealed trait WorkflowStep extends Product with Serializable {
 object WorkflowStep {
 
   val CheckoutFull: WorkflowStep = Use(
-    UseRef.Public("actions", "checkout", "v2"),
+    UseRef.Public("actions", "checkout", "v3"),
     name = Some("Checkout current branch (full)"),
     params = Map("fetch-depth" -> "0"))
 
   val Checkout: WorkflowStep = Use(
-    UseRef.Public("actions", "checkout", "v2"),
+    UseRef.Public("actions", "checkout", "v3"),
     name = Some("Checkout current branch (fast)"))
 
   def SetupJava(versions: List[JavaSpec]): List[WorkflowStep] =
@@ -56,7 +56,7 @@ object WorkflowStep {
             params = Map("distribution" -> dist.rendering, "java-version" -> version)
           ),
           WorkflowStep.Use(
-            UseRef.Public("actions", "setup-java", "v2"),
+            UseRef.Public("actions", "setup-java", "v3"),
             name = Some(s"Setup Java (${jv.render})"),
             cond = cond,
             params = Map(
@@ -69,7 +69,7 @@ object WorkflowStep {
 
       case jv @ JavaSpec(dist, version) =>
         WorkflowStep.Use(
-          UseRef.Public("actions", "setup-java", "v2"),
+          UseRef.Public("actions", "setup-java", "v3"),
           name = Some(s"Setup Java (${jv.render})"),
           cond = Some(s"matrix.java == '${jv.render}'"),
           params = Map("distribution" -> dist.rendering, "java-version" -> version)

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/WorkflowStep.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/WorkflowStep.scala
@@ -49,7 +49,7 @@ object WorkflowStep {
         val id = s"download-java-${dist.rendering}-$version"
         List(
           WorkflowStep.Use(
-            UseRef.Public("typelevel", "download-java", "v1"),
+            UseRef.Public("typelevel", "download-java", "v2"),
             name = Some(s"Download Java (${jv.render})"),
             id = Some(id),
             cond = cond,
@@ -77,7 +77,7 @@ object WorkflowStep {
     }
 
   val Tmate: WorkflowStep =
-    Use(UseRef.Public("mxschmitt", "action-tmate", "v2"), name = Some("Setup tmate session"))
+    Use(UseRef.Public("mxschmitt", "action-tmate", "v3"), name = Some("Setup tmate session"))
 
   def ComputeVar(name: String, cmd: String): WorkflowStep =
     Run(

--- a/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
+++ b/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
@@ -203,7 +203,7 @@ object TypelevelSitePlugin extends AutoPlugin {
       def publishSiteWorkflowStep(publishPredicate: RefPredicate) =
         List(
           WorkflowStep.Use(
-            UseRef.Public("peaceiris", "actions-gh-pages", "v3.8.0"),
+            UseRef.Public("peaceiris", "actions-gh-pages", "v3.9.0"),
             Map(
               "github_token" -> s"$${{ secrets.GITHUB_TOKEN }}",
               "publish_dir" -> (ThisBuild / baseDirectory)


### PR DESCRIPTION
I try to avoid major bumps of dependencies in minor versions, but 0.4 will eventually cease to function without this.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/