### PR TITLE
Only run fmt/header/mima etc. checks on primary os

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,22 +86,22 @@ jobs:
         run: sbt githubWorkflowCheck
 
       - name: Check headers and formatting
-        if: matrix.java == 'temurin@8'
+        if: matrix.java == 'temurin@8' && matrix.os == 'ubuntu-latest'
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' headerCheckAll scalafmtCheckAll 'project /' scalafmtSbtCheck
 
       - name: Test
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' test
 
       - name: Check scalafix lints
-        if: matrix.java == 'temurin@8'
+        if: matrix.java == 'temurin@8' && matrix.os == 'ubuntu-latest'
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' 'scalafixAll --check'
 
       - name: Check binary compatibility
-        if: matrix.java == 'temurin@8'
+        if: matrix.java == 'temurin@8' && matrix.os == 'ubuntu-latest'
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' mimaReportBinaryIssues
 
       - name: Generate API documentation
-        if: matrix.java == 'temurin@8'
+        if: matrix.java == 'temurin@8' && matrix.os == 'ubuntu-latest'
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' doc
 
       - name: Make target directories

--- a/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
@@ -63,7 +63,7 @@ object TypelevelCiPlugin extends AutoPlugin {
             WorkflowStep.Sbt(
               List("headerCheckAll", "scalafmtCheckAll", "project /", "scalafmtSbtCheck"),
               name = Some("Check headers and formatting"),
-              cond = Some(primaryJavaCond.value)
+              cond = Some(primaryJavaOSCond.value)
             )
           )
         case (true, false) => // headers
@@ -71,7 +71,7 @@ object TypelevelCiPlugin extends AutoPlugin {
             WorkflowStep.Sbt(
               List("headerCheckAll"),
               name = Some("Check headers"),
-              cond = Some(primaryJavaCond.value)
+              cond = Some(primaryJavaOSCond.value)
             )
           )
         case (false, true) => // formatting
@@ -79,7 +79,7 @@ object TypelevelCiPlugin extends AutoPlugin {
             WorkflowStep.Sbt(
               List("scalafmtCheckAll", "project /", "scalafmtSbtCheck"),
               name = Some("Check formatting"),
-              cond = Some(primaryJavaCond.value)
+              cond = Some(primaryJavaOSCond.value)
             )
           )
         case (false, false) => Nil // nada
@@ -95,7 +95,7 @@ object TypelevelCiPlugin extends AutoPlugin {
             WorkflowStep.Sbt(
               List("scalafixAll --check"),
               name = Some("Check scalafix lints"),
-              cond = Some(primaryJavaCond.value)
+              cond = Some(primaryJavaOSCond.value)
             )
           )
         else Nil
@@ -106,7 +106,7 @@ object TypelevelCiPlugin extends AutoPlugin {
             WorkflowStep.Sbt(
               List("mimaReportBinaryIssues"),
               name = Some("Check binary compatibility"),
-              cond = Some(primaryJavaCond.value)
+              cond = Some(primaryJavaOSCond.value)
             ))
         else Nil
 
@@ -116,7 +116,7 @@ object TypelevelCiPlugin extends AutoPlugin {
             WorkflowStep.Sbt(
               List("doc"),
               name = Some("Generate API documentation"),
-              cond = Some(primaryJavaCond.value)
+              cond = Some(primaryJavaOSCond.value)
             )
           )
         else Nil
@@ -126,9 +126,10 @@ object TypelevelCiPlugin extends AutoPlugin {
     githubWorkflowJavaVersions := Seq(JavaSpec.temurin("8"))
   )
 
-  private val primaryJavaCond = Def.setting {
+  private val primaryJavaOSCond = Def.setting {
     val java = githubWorkflowJavaVersions.value.head
-    s"matrix.java == '${java.render}'"
+    val os = githubWorkflowOSes.value.head
+    s"matrix.java == '${java.render}' && matrix.os == '${os}'"
   }
 
 }

--- a/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
+++ b/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
@@ -115,9 +115,4 @@ object TypelevelPlugin extends AutoPlugin {
   // override for bincompat
   override def projectSettings = immutable.Seq.empty
 
-  private val primaryJavaCond = Def.setting {
-    val java = githubWorkflowJavaVersions.value.head
-    s"matrix.java == '${java.render}'"
-  }
-
 }


### PR DESCRIPTION
This was an oversight, since few builds test on multiple OSes. But both Scala Native and the Cats Effect I/O-integrated JVM runtime are putting more pressure to check on other OSes.