### PR TITLE
Add helpful error for misplaced managed sources

### DIFF
--- a/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
+++ b/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
@@ -281,7 +281,19 @@ object TypelevelSettingsPlugin extends AutoPlugin {
     },
     packageSrc / mappings ++= {
       val base = sourceManaged.value
-      managedSources.value.map(file => file -> file.relativeTo(base).get.getPath)
+      managedSources.value.map { file =>
+        file.relativeTo(base) match {
+          case Some(relative) => file -> relative.getPath
+          case None =>
+            throw new RuntimeException(
+              s"""|Expected managed sources in:
+                  |$base
+                  |But found them here:
+                  |$file
+                  |""".stripMargin
+            )
+        }
+      }
     }
   )
 


### PR DESCRIPTION
Closes https://github.com/typelevel/sbt-typelevel/issues/373.

Just ran into this again, so now I've got a pretty good idea of what the user mistake is in this situation.

This error message would have helped in the original issue since we would have realized it's trying to mix Scala 2 and Scala 3 sources.