### PR TITLE
Add Laika API link configuration

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -64,6 +64,7 @@ Instead of using the super-plugins, for finer-grained control you can always add
 -  `TypelevelSitePlugin`: Sets up an [mdoc](https://scalameta.org/mdoc/)/[Laika](https://planet42.github.io/Laika/)-generated website, automatically published to GitHub pages in CI.
 - `tlSitePublishBranch` (setting): The branch to publish the site from on every push. Set this to `None` if you only want to update the site on tag releases. (default: `main`)
 - `tlSitePublishTags` (setting): Defines whether the site should be published on tag releases. Note on setting this to `true` requires the `tlSitePublishBranch` setting to be set to `None`. (default: `false`)
+- `tlSiteApiLinks` (setting): Map of package prefixes to API documentation sites for use with Laika API links. (default: * -> `tlSiteApiUrl`, if available)
 - `tlSiteApiUrl` (setting): URL to the API docs. (default: `None`)
 - `tlSiteHeliumConfig` (setting): the Laika Helium config. (default: how the sbt-typelevel site looks)
 


### PR DESCRIPTION
This PR sets up the [Laika configuration for API links](https://planet42.github.io/Laika/0.18/03-preparing-content/02-navigation.html#linking-to-api-documentation), based on a map of package prefixes to scaladoc URLs provided by the plugin user. If none are provided, it will default to `tlSiteApiUrl` if available.

This allows links to the API docs to be easily added to Typelevel microsites, eg.: `@:api(cats.data.Chain)`

This implementation is based on the review comments for https://github.com/typelevel/sbt-typelevel/pull/225 and will supercede that PR.