### PR TITLE
Use `-source:3.2-migration` on Scala 3.2 (when cross-compiling)

### DIFF
--- a/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
+++ b/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
@@ -152,9 +152,14 @@ object TypelevelSettingsPlugin extends AutoPlugin {
     scalacOptions ++= {
       if (tlIsScala3.value && crossScalaVersions.value.forall(_.startsWith("3.")))
         Seq("-Ykind-projector:underscores")
-      else if (tlIsScala3.value)
-        Seq("-language:implicitConversions", "-Ykind-projector", "-source:3.0-migration")
-      else
+      else if (tlIsScala3.value) {
+        val migrationFlag = scalaVersion.value match {
+          case V(V(3, minor, _, _)) if minor < 2 => "-source:3.0-migration"
+          case V(V(3, 2, _, _)) => "-source:3.2-migration"
+          case V(V(3, minor, _, _)) if minor > 2 => "-source:future-migration"
+        }
+        Seq("-language:implicitConversions", "-Ykind-projector", migrationFlag)
+      } else
         Seq("-language:_")
     },
     Test / scalacOptions ++= {


### PR DESCRIPTION
By chance I stumbled on this flag today and h/t to @valencik and @samspills for concurrently discovering a scenario where it makes a difference in https://github.com/cozydev-pink/snakecase/pull/1.

Here is output of `scalac --help` for 3.2.2. Notice there is no `3.1-migration` option ...
```
              -source  source version
                       Default 3.2
                       Choices 3.0-migration, 3.0, 3.1, 3.2-migration, 3.2, future-migration, future
```