### PR TITLE
Fixing section title sizing for code blocks

### DIFF
--- a/site/src/main/resources/org/typelevel/sbt/site/helium/site/styles.css
+++ b/site/src/main/resources/org/typelevel/sbt/site/helium/site/styles.css
@@ -3,3 +3,27 @@ header img {
   width: auto;
   margin-top: 6px;
 }
+
+h1>code {
+  font-size: var(--header1-font-size);
+}
+
+h2>code {
+  font-size: var(--header2-font-size);
+}
+
+h3>code {
+  font-size: var(--header3-font-size);
+}
+
+h4>code {
+  font-size: var(--header4-font-size);
+}
+
+h5>code {
+  font-size: var(--header5-font-size);
+}
+
+h6>code {
+  font-size: var(--header6-font-size);
+}


### PR DESCRIPTION
It should fix this:
![immagine](https://user-images.githubusercontent.com/41690956/222748952-42f4a5df-696e-47c3-8d2d-5f02c0ceb3e5.png)

Testing it on sbt-typelevel itself resulted in this for an h1:
![immagine](https://user-images.githubusercontent.com/41690956/222749661-8a1d0054-1013-40ed-999b-6c90f545ba02.png)

