### PR TITLE
Revert "Use `-source:3.2-migration` on Scala 3.2 (when cross-compiling)"

### DIFF
--- a/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
+++ b/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
@@ -152,14 +152,9 @@ object TypelevelSettingsPlugin extends AutoPlugin {
     scalacOptions ++= {
       if (tlIsScala3.value && crossScalaVersions.value.forall(_.startsWith("3.")))
         Seq("-Ykind-projector:underscores")
-      else if (tlIsScala3.value) {
-        val migrationFlag = scalaVersion.value match {
-          case V(V(3, minor, _, _)) if minor < 2 => "-source:3.0-migration"
-          case V(V(3, 2, _, _)) => "-source:3.2-migration"
-          case V(V(3, minor, _, _)) if minor > 2 => "-source:future-migration"
-        }
-        Seq("-language:implicitConversions", "-Ykind-projector", migrationFlag)
-      } else
+      else if (tlIsScala3.value)
+        Seq("-language:implicitConversions", "-Ykind-projector", "-source:3.0-migration")
+      else
         Seq("-language:_")
     },
     Test / scalacOptions ++= {


### PR DESCRIPTION
Reverts typelevel/sbt-typelevel#467, explanation in https://github.com/typelevel/sbt-typelevel/pull/467#issuecomment-1454299189.