### PR TITLE
Condense GHA step summaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
           (echo "$PGP_PASSPHRASE"; echo; echo) | gpg --command-fd 0 --pinentry-mode loopback --change-passphrase $(gpg --list-secret-keys --with-colons 2> /dev/null | grep '^sec:' | cut --delimiter ':' --fields 5 | tail -n 1)
 
       - name: Publish
-        run: sbt '++ ${{ matrix.scala }}' tlRelease
+        run: sbt '++ ${{ matrix.scala }}' tlCiRelease
 
   site:
     name: Generate Site

--- a/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
@@ -140,13 +140,26 @@ object TypelevelCiPlugin extends AutoPlugin {
       projectName: String,
       scalaVersion: String,
       results: Tests.Output): String = {
-    val tableHeader: String =
-      s"### ${projectName} Tests Results\n" +
-        s"To rerun them locally use `++${scalaVersion} ${projectName}/test`\n" +
-        "|SuiteName|Result|Passed|Failed|Errors|Skipped|Ignored|Canceled|Pending|\n" +
-        "|-:|-|-|-|-|-|-|-|-|\n"
 
-    val renderedResults = results.events.map {
+    val testHeader: String =
+      s"""|### ${projectName} Tests Results
+          |To run them locally use `++${scalaVersion} ${projectName}/test`
+          |"""
+
+    val testSummary: String =
+      results
+        .summaries
+        .map { case Tests.Summary(name, text) => s"$name: $text" }
+        .mkString("", "\n", "\n\n")
+
+    val tableHeader: String =
+      s"""|<details>
+          |
+          ||SuiteName|Result|Passed|Failed|Errors|Skipped|Ignored|Canceled|Pending|
+          ||-:|-|-|-|-|-|-|-|-|
+          |"""
+
+    val tableBody = results.events.map {
       case (suiteName, suiteResult) =>
         List(
           suiteName,
@@ -161,7 +174,10 @@ object TypelevelCiPlugin extends AutoPlugin {
         ).mkString("|", "|", "|")
     }
 
-    if (renderedResults.nonEmpty) renderedResults.mkString(tableHeader, "\n", "\n\n")
+    val table: String = tableBody.mkString(tableHeader, "\n", "\n</details>\n\n")
+
+    if (results.events.nonEmpty)
+      testHeader + testSummary + table
     else ""
   }
 

--- a/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
@@ -144,7 +144,7 @@ object TypelevelCiPlugin extends AutoPlugin {
     val testHeader: String =
       s"""|### ${projectName} Tests Results
           |To run them locally use `++${scalaVersion} ${projectName}/test`
-          |"""
+          |""".stripMargin
 
     val testSummary: String =
       results
@@ -157,7 +157,7 @@ object TypelevelCiPlugin extends AutoPlugin {
           |
           ||SuiteName|Result|Passed|Failed|Errors|Skipped|Ignored|Canceled|Pending|
           ||-:|-|-|-|-|-|-|-|-|
-          |"""
+          |""".stripMargin
 
     val tableBody = results.events.map {
       case (suiteName, suiteResult) =>

--- a/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
@@ -142,15 +142,9 @@ object TypelevelCiPlugin extends AutoPlugin {
       results: Tests.Output): String = {
 
     val testHeader: String =
-      s"""|### ${projectName} Tests Results
+      s"""|### ${projectName} Tests Results: ${results.overall}
           |To run them locally use `++${scalaVersion} ${projectName}/test`
           |""".stripMargin
-
-    val testSummary: String =
-      results
-        .summaries
-        .map { case Tests.Summary(name, text) => s"$name: $text" }
-        .mkString("", "\n", "\n\n")
 
     val tableHeader: String =
       s"""|<details>
@@ -177,7 +171,7 @@ object TypelevelCiPlugin extends AutoPlugin {
     val table: String = tableBody.mkString(tableHeader, "\n", "\n</details>\n\n")
 
     if (results.events.nonEmpty)
-      testHeader + testSummary + table
+      testHeader + table
     else ""
   }
 

--- a/sonatype-ci-release/src/main/scala/org/typelevel/sbt/TypelevelSonatypeCiReleasePlugin.scala
+++ b/sonatype-ci-release/src/main/scala/org/typelevel/sbt/TypelevelSonatypeCiReleasePlugin.scala
@@ -78,7 +78,7 @@ object TypelevelSonatypeCiReleasePlugin extends AutoPlugin {
             s"""|```scala
                 |resolvers += "${repo.name}" at "${repo.root}"
                 |```
-                |"""
+                |""".stripMargin
         }
 
         GitHubActionsPlugin.appendtoStepSummary(

--- a/sonatype-ci-release/src/main/scala/org/typelevel/sbt/TypelevelSonatypeCiReleasePlugin.scala
+++ b/sonatype-ci-release/src/main/scala/org/typelevel/sbt/TypelevelSonatypeCiReleasePlugin.scala
@@ -21,7 +21,6 @@ import org.typelevel.sbt.gha.GenerativePlugin.autoImport._
 import org.typelevel.sbt.gha.GitHubActionsPlugin
 import sbt.Keys._
 import sbt._
-
 import xerial.sbt.Sonatype.autoImport._
 
 object TypelevelSonatypeCiReleasePlugin extends AutoPlugin {

--- a/sonatype-ci-release/src/main/scala/org/typelevel/sbt/TypelevelSonatypeCiReleasePlugin.scala
+++ b/sonatype-ci-release/src/main/scala/org/typelevel/sbt/TypelevelSonatypeCiReleasePlugin.scala
@@ -43,6 +43,9 @@ object TypelevelSonatypeCiReleasePlugin extends AutoPlugin {
   override def globalSettings =
     Seq(tlCiReleaseTags := true, tlCiReleaseBranches := Seq())
 
+  override def projectSettings =
+    Seq(commands += tlCiReleaseCommand)
+
   override def buildSettings = Seq(
     githubWorkflowEnv ++= List(
       "SONATYPE_USERNAME",
@@ -66,7 +69,7 @@ object TypelevelSonatypeCiReleasePlugin extends AutoPlugin {
     )
   )
 
-  private def sonatypeBundleReleaseIfRelevant: Command =
+  private def tlCiReleaseCommand: Command =
     Command.command("tlCiRelease") { state =>
       val newState = Command.process("tlRelease", state)
       newState.getSetting(version).foreach { v =>


### PR DESCRIPTION
Follow-up to https://github.com/typelevel/sbt-typelevel/pull/451 that condenses the summaries a bit, which would be overwhelming for projects like http4s which have 3 scalas x 3 platforms x 10 platforms = 90 modules to report about :)

Tried it out here: https://github.com/armanbilge/fs2-dom/actions/runs/4328492513

<img width="918" alt="Screen Shot 2023-03-03 at 5 05 34 PM" src="https://user-images.githubusercontent.com/3119428/222864308-6bf7499c-93c5-4049-a7ca-770d61c70ea2.png">

If you unfold the "details" in test summary you get this:

<img width="880" alt="Screen Shot 2023-03-03 at 5 05 56 PM" src="https://user-images.githubusercontent.com/3119428/222864336-cc96b4bc-8adf-42fe-addd-dd5d7ea8b0f7.png">
