### PR TITLE
Update sbt-header from 5.6.0 to 5.9.0

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")
-addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.0")
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.9.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.2.0")


### PR DESCRIPTION
Apparently, `sbt-header` `v5.6.0` is [no longer available](https://repo1.maven.org/maven2/de/heikoseeberger/sbt-header_2.12_1.0/).