### PR TITLE
Use new sbt-crossproject settings

### DIFF
--- a/mergify/build.sbt
+++ b/mergify/build.sbt
@@ -1,1 +1,2 @@
 libraryDependencies += "io.circe" %% "circe-yaml" % "0.14.2"
+addSbtPlugin("org.portable-scala" % "sbt-crossproject" % "1.3.1")

--- a/mergify/src/main/scala/org/typelevel/sbt/mergify/MergifyPlugin.scala
+++ b/mergify/src/main/scala/org/typelevel/sbt/mergify/MergifyPlugin.scala
@@ -18,6 +18,7 @@ package org.typelevel.sbt.mergify
 
 import org.typelevel.sbt.gha._
 import sbt._
+import sbtcrossproject.CrossPlugin.autoImport._
 
 import java.nio.file.Path
 
@@ -152,13 +153,7 @@ object MergifyPlugin extends AutoPlugin {
   }
 
   private lazy val projectLabel = Def.setting {
-    val path = (Compile / sourceDirectories)
-      .?
-      .value
-      .getOrElse(Seq.empty)
-      .map(_.toPath)
-      .foldLeft(baseDirectory.value.toPath)(commonAncestor(_, _))
-
+    val path = crossProjectBaseDirectory.?.value.getOrElse(baseDirectory.value).toPath
     val label = path.getFileName.toString
 
     def isRoot = path == (LocalRootProject / baseDirectory).value.toPath

--- a/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
+++ b/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
@@ -260,17 +260,18 @@ object TypelevelSettingsPlugin extends AutoPlugin {
   private val perConfigSettings = Seq(
     unmanagedSourceDirectories ++= {
       def extraDirs(suffix: String) =
-        if (crossProjectPlatform.?.value.isDefined)
-          List(CrossType.Pure, CrossType.Full).flatMap {
-            _.sharedSrcDir(baseDirectory.value, Defaults.nameForSrc(configuration.value.name))
+        crossProjectCrossType.?.value match {
+          case Some(crossType) =>
+            crossType
+              .sharedSrcDir(baseDirectory.value, Defaults.nameForSrc(configuration.value.name))
               .toList
               .map(f => file(f.getPath + suffix))
-          }
-        else
-          List(
-            baseDirectory.value / "src" / Defaults.nameForSrc(
-              configuration.value.name) / s"scala$suffix"
-          )
+          case None =>
+            List(
+              baseDirectory.value / "src" /
+                Defaults.nameForSrc(configuration.value.name) / s"scala$suffix"
+            )
+        }
 
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, y)) if y <= 12 => extraDirs("-2.12-")

--- a/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
+++ b/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
@@ -22,7 +22,6 @@ import org.typelevel.sbt.kernel.GitHelper
 import org.typelevel.sbt.kernel.V
 import sbt._
 import sbtcrossproject.CrossPlugin.autoImport._
-import sbtcrossproject.CrossType
 
 import java.io.File
 import java.lang.management.ManagementFactory


### PR DESCRIPTION
`crossProjectCrossType` identifies the cross type of a cross project, so we know where the shared sources live (and thus where we should look for additional `scala-2.12-` and `scala-2.13+` source directories).

`crossProjectBaseDirectory` identifies the effective base directory of a project, useful for the mergify auto-labeling feature.

This should be more robust than our previous heuristical hacks.

Further reading:
- https://github.com/portable-scala/sbt-crossproject/pull/152