### PR TITLE
use githubWorkflowBuildSbtStepPreamble in publish step

### DIFF
--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativePlugin.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativePlugin.scala
@@ -712,6 +712,7 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}
             githubWorkflowPublishPreamble.value.toList :::
             githubWorkflowPublish.value.toList :::
             githubWorkflowPublishPostamble.value.toList,
+          sbtStepPreamble = githubWorkflowBuildSbtStepPreamble.value.toList,
           cond = Some(publicationCond.value),
           oses = githubWorkflowOSes.value.toList.take(1),
           scalas = List(scalaVersion.value),

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/WorkflowJob.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/WorkflowJob.scala
@@ -20,7 +20,7 @@ final case class WorkflowJob(
     id: String,
     name: String,
     steps: List[WorkflowStep],
-    sbtStepPreamble: List[String] = List(s"++ $${{ matrix.scala }}"),
+    sbtStepPreamble: List[String] = List.empty,
     cond: Option[String] = None,
     env: Map[String, String] = Map(),
     oses: List[String] = List("ubuntu-latest"),


### PR DESCRIPTION
I think this may have been an oversight.

We don't have to change the default value of `sbtStepPreamble`, but with this change, the default value is never actually used anymore.