### PR TITLE
Migrate Laika to `0.19`

### DIFF
--- a/docs/site.md
+++ b/docs/site.md
@@ -53,4 +53,4 @@ lazy val unidocs = project
 
 ### How can I customize my website's appearance?
 
-We refer you to the comprehensive [Laika manual](https://planet42.github.io/Laika/index.html) and specifically the [`laikaTheme` setting](https://planet42.github.io/Laika/0.18/02-running-laika/01-sbt-plugin.html#laikatheme-setting).
+We refer you to the comprehensive [Laika manual](https://planet42.github.io/Laika/index.html) and specifically the [`laikaTheme` setting](https://planet42.github.io/Laika/latest/02-running-laika/01-sbt-plugin.html#laikatheme-setting).

--- a/site/build.sbt
+++ b/site/build.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.24")
-addSbtPlugin("org.planet42" % "laika-sbt" % "0.18.2")
+addSbtPlugin("org.planet42" % "laika-sbt" % "0.19.1")

--- a/site/src/main/resources/org/typelevel/sbt/site/helium/default.template.html
+++ b/site/src/main/resources/org/typelevel/sbt/site/helium/default.template.html
@@ -4,7 +4,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="generator" content="Laika 0.18.1 + Helium Theme" />
+    <meta name="generator" content="Laika 0.19.1 + Helium Theme" />
     <title>${cursor.currentDocument.title}</title>
     @:for(laika.site.metadata.authors)
       <meta name="author" content="${_}"/>
@@ -18,8 +18,8 @@
     @:for(helium.webFonts)
       <link rel="stylesheet" href="${_}">
     @:@
-    @:linkCSS { paths = ${helium.site.includeCSS} }
-    @:linkJS { paths = ${helium.site.includeJS} }
+    @:linkCSS
+    @:linkJS
     @:heliumInitVersions
     @:heliumInitPreview(container)
     <script> /* for avoiding page load transitions */ </script>
@@ -37,7 +37,7 @@
         <div id="version-menu-container">
           <a id="version-menu-toggle" class="text-link drop-down-toggle" href="#">
             @:if(laika.versioned)
-            ${helium.topBar.versionPrefix} ${laika.versions.currentVersion.displayValue}
+            ${helium.site.topNavigation.versionPrefix} ${laika.versions.currentVersion.displayValue}
             @:else
             Documentation
             @:@
@@ -50,15 +50,23 @@
         @:@
       </div>
 
-      ${?helium.topBar.home}
+      ${?helium.site.topNavigation.home}
 
-      ${?helium.topBar.links}
+      <div class="row links">
+        @:for(helium.site.topNavigation.links)
+        ${_}
+        @:@
+      </div>
 
     </header>
 
     <nav id="sidebar">
 
-      ${?helium.topBar.phoneLinks}
+      <div class="row">
+        @:for(helium.site.topNavigation.phoneLinks)
+        ${_}
+        @:@
+      </div>
 
       @:navigationTree {
         entries = [

--- a/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
+++ b/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
@@ -34,7 +34,6 @@ import org.typelevel.sbt.site._
 import sbt._
 
 import scala.annotation.nowarn
-
 import Keys._
 import MdocPlugin.autoImport._
 import LaikaPlugin.autoImport._
@@ -42,6 +41,7 @@ import gha.GenerativePlugin
 import GenerativePlugin.autoImport._
 import TypelevelKernelPlugin._
 import TypelevelKernelPlugin.autoImport._
+import laika.io.model.FilePath
 
 object TypelevelSitePlugin extends AutoPlugin {
 
@@ -340,8 +340,9 @@ object TypelevelSitePlugin extends AutoPlugin {
 
       val applyFlags = applyIf(laikaIncludeEPUB.value, _.withEPUBDownloads)
         .andThen(applyIf(laikaIncludePDF.value, _.withPDFDownloads))
-        .andThen(
-          applyIf(laikaIncludeAPI.value, _.withAPIDirectory(Settings.apiTargetDirectory.value)))
+        .andThen(applyIf(
+          laikaIncludeAPI.value,
+          _.withAPIDirectory(FilePath.fromJavaFile(Settings.apiTargetDirectory.value))))
         .andThen(applyIf(previewConfig.isVerbose, _.verbose))
 
       val config = ServerConfig

--- a/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
+++ b/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
@@ -23,6 +23,7 @@ import laika.helium.config.Favicon
 import laika.helium.config.HeliumIcon
 import laika.helium.config.IconLink
 import laika.helium.config.ImageLink
+import laika.io.model.FilePath
 import laika.sbt.LaikaPlugin
 import laika.theme.ThemeProvider
 import laika.theme.config.Font
@@ -34,6 +35,7 @@ import org.typelevel.sbt.site._
 import sbt._
 
 import scala.annotation.nowarn
+
 import Keys._
 import MdocPlugin.autoImport._
 import LaikaPlugin.autoImport._
@@ -41,7 +43,6 @@ import gha.GenerativePlugin
 import GenerativePlugin.autoImport._
 import TypelevelKernelPlugin._
 import TypelevelKernelPlugin.autoImport._
-import laika.io.model.FilePath
 
 object TypelevelSitePlugin extends AutoPlugin {
 

--- a/site/src/main/scala/org/typelevel/sbt/site/TypelevelHeliumExtensions.scala
+++ b/site/src/main/scala/org/typelevel/sbt/site/TypelevelHeliumExtensions.scala
@@ -17,7 +17,7 @@
 package org.typelevel.sbt.site
 
 import cats.effect.Resource
-import cats.effect.Sync
+import cats.effect.kernel.Async
 import laika.ast.Path
 import laika.config.Config
 import laika.io.model.InputTree
@@ -60,15 +60,15 @@ object TypelevelHeliumExtensions {
       scala3: Boolean,
       apiUrl: Option[URL]
   ): ThemeProvider = new ThemeProvider {
-    def build[F[_]](implicit F: Sync[F]): Resource[F, Theme[F]] =
+    def build[F[_]](implicit F: Async[F]): Resource[F, Theme[F]] =
       ThemeBuilder[F]("Typelevel Helium Extensions")
         .addInputs(
           InputTree[F]
-            .addStream(
+            .addInputStream(
               F.blocking(getClass.getResourceAsStream("helium/default.template.html")),
               DefaultTemplatePath.forHTML
             )
-            .addStream(
+            .addInputStream(
               F.blocking(getClass.getResourceAsStream("helium/site/styles.css")),
               Path.Root / "site" / "styles.css"
             )


### PR DESCRIPTION
As a matter of fact, I haven't tried to build any downstream project's microsite but building of `sbt-typelevel` microsite works well. It would be good if someone double-checks the results. 