### PR TITLE
Add re-introduced unused/discard warnings for scala >3.3.0

### DIFF
--- a/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
+++ b/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
@@ -105,7 +105,20 @@ object TypelevelSettingsPlugin extends AutoPlugin {
 
       val warningsDotty = Seq.empty
 
+      val warnings33 = Seq(
+        "-Wunused:implicits",
+        "-Wunused:explicits",
+        "-Wunused:imports",
+        "-Wunused:locals",
+        "-Wunused:params",
+        "-Wunused:privates",
+        "-Wvalue-discard"
+      )
+
       scalaVersion.value match {
+        case V(V(3, minor, _, _)) if minor >= 3 =>
+          warnings33
+
         case V(V(3, _, _, _)) =>
           warningsDotty
 


### PR DESCRIPTION
This PR prepares the plugin for the official scala 3.3.0 release (it is tagged, just not released quite yet https://github.com/lampepfl/dotty/releases/tag/3.3.0). It adds back all the warnings for unused and discarded values that is re-added in this release.