### PR TITLE
Cleanup after scalafix update

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,9 +28,6 @@ ThisBuild / mergifyPrRules += MergifyPrRule(
   )
 )
 ThisBuild / mergifyRequiredJobs ++= Seq("validate-steward", "site")
-ThisBuild / scalafixDependencies ++= Seq(
-  "com.github.liancheng" %% "organize-imports" % "0.6.0"
-)
 
 lazy val root = tlCrossRootProject.aggregate(
   kernel,


### PR DESCRIPTION
The organize imports rule is now buildin.
Follow up to: #522 
See https://github.com/scalacenter/scalafix/releases/tag/v0.11.0