### PR TITLE
Use vanilla setup-java action, update setup-graalvm action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,8 @@ jobs:
           - temurin@8
           - temurin@11
           - temurin@17
-          - graal_latest@17
+          - graalvm@17
+          - corretto@17
         project: [sbt-typelevelJVM]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
@@ -43,83 +44,69 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Download Java (temurin@8)
-        id: download-java-temurin-8
-        if: matrix.java == 'temurin@8'
-        uses: typelevel/download-java@v2
-        with:
-          distribution: temurin
-          java-version: 8
-
       - name: Setup Java (temurin@8)
         id: setup-java-temurin-8
         if: matrix.java == 'temurin@8'
         uses: actions/setup-java@v3
         with:
-          distribution: jdkfile
+          distribution: temurin
           java-version: 8
-          jdkFile: ${{ steps.download-java-temurin-8.outputs.jdkFile }}
           cache: sbt
 
       - name: sbt update
         if: matrix.java == 'temurin@8' && steps.setup-java-temurin-8.outputs.cache-hit == 'false'
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' reload +update
 
-      - name: Download Java (temurin@11)
-        id: download-java-temurin-11
-        if: matrix.java == 'temurin@11'
-        uses: typelevel/download-java@v2
-        with:
-          distribution: temurin
-          java-version: 11
-
       - name: Setup Java (temurin@11)
         id: setup-java-temurin-11
         if: matrix.java == 'temurin@11'
         uses: actions/setup-java@v3
         with:
-          distribution: jdkfile
+          distribution: temurin
           java-version: 11
-          jdkFile: ${{ steps.download-java-temurin-11.outputs.jdkFile }}
           cache: sbt
 
       - name: sbt update
         if: matrix.java == 'temurin@11' && steps.setup-java-temurin-11.outputs.cache-hit == 'false'
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' reload +update
 
-      - name: Download Java (temurin@17)
-        id: download-java-temurin-17
-        if: matrix.java == 'temurin@17'
-        uses: typelevel/download-java@v2
-        with:
-          distribution: temurin
-          java-version: 17
-
       - name: Setup Java (temurin@17)
         id: setup-java-temurin-17
         if: matrix.java == 'temurin@17'
         uses: actions/setup-java@v3
         with:
-          distribution: jdkfile
+          distribution: temurin
           java-version: 17
-          jdkFile: ${{ steps.download-java-temurin-17.outputs.jdkFile }}
           cache: sbt
 
       - name: sbt update
         if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' reload +update
 
-      - name: Setup GraalVM (graal_latest@17)
-        id: setup-graalvm-latest-17
-        if: matrix.java == 'graal_latest@17'
+      - name: Setup Java (graalvm@17)
+        id: setup-java-graalvm-17
+        if: matrix.java == 'graalvm@17'
         uses: graalvm/setup-graalvm@v1
         with:
-          version: latest
+          distribution: graalvm
           java-version: 17
           cache: sbt
 
       - name: sbt update
-        if: matrix.java == 'graal_latest@17' && steps.setup-graalvm-latest-17.outputs.cache-hit == 'false'
+        if: matrix.java == 'graalvm@17' && steps.setup-java-graalvm-17.outputs.cache-hit == 'false'
+        run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' reload +update
+
+      - name: Setup Java (corretto@17)
+        id: setup-java-corretto-17
+        if: matrix.java == 'corretto@17'
+        uses: actions/setup-java@v3
+        with:
+          distribution: corretto
+          java-version: 17
+          cache: sbt
+
+      - name: sbt update
+        if: matrix.java == 'corretto@17' && steps.setup-java-corretto-17.outputs.cache-hit == 'false'
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' reload +update
 
       - name: Check that workflows are up to date
@@ -175,83 +162,69 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Download Java (temurin@8)
-        id: download-java-temurin-8
-        if: matrix.java == 'temurin@8'
-        uses: typelevel/download-java@v2
-        with:
-          distribution: temurin
-          java-version: 8
-
       - name: Setup Java (temurin@8)
         id: setup-java-temurin-8
         if: matrix.java == 'temurin@8'
         uses: actions/setup-java@v3
         with:
-          distribution: jdkfile
+          distribution: temurin
           java-version: 8
-          jdkFile: ${{ steps.download-java-temurin-8.outputs.jdkFile }}
           cache: sbt
 
       - name: sbt update
         if: matrix.java == 'temurin@8' && steps.setup-java-temurin-8.outputs.cache-hit == 'false'
         run: sbt reload +update
 
-      - name: Download Java (temurin@11)
-        id: download-java-temurin-11
-        if: matrix.java == 'temurin@11'
-        uses: typelevel/download-java@v2
-        with:
-          distribution: temurin
-          java-version: 11
-
       - name: Setup Java (temurin@11)
         id: setup-java-temurin-11
         if: matrix.java == 'temurin@11'
         uses: actions/setup-java@v3
         with:
-          distribution: jdkfile
+          distribution: temurin
           java-version: 11
-          jdkFile: ${{ steps.download-java-temurin-11.outputs.jdkFile }}
           cache: sbt
 
       - name: sbt update
         if: matrix.java == 'temurin@11' && steps.setup-java-temurin-11.outputs.cache-hit == 'false'
         run: sbt reload +update
 
-      - name: Download Java (temurin@17)
-        id: download-java-temurin-17
-        if: matrix.java == 'temurin@17'
-        uses: typelevel/download-java@v2
-        with:
-          distribution: temurin
-          java-version: 17
-
       - name: Setup Java (temurin@17)
         id: setup-java-temurin-17
         if: matrix.java == 'temurin@17'
         uses: actions/setup-java@v3
         with:
-          distribution: jdkfile
+          distribution: temurin
           java-version: 17
-          jdkFile: ${{ steps.download-java-temurin-17.outputs.jdkFile }}
           cache: sbt
 
       - name: sbt update
         if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
         run: sbt reload +update
 
-      - name: Setup GraalVM (graal_latest@17)
-        id: setup-graalvm-latest-17
-        if: matrix.java == 'graal_latest@17'
+      - name: Setup Java (graalvm@17)
+        id: setup-java-graalvm-17
+        if: matrix.java == 'graalvm@17'
         uses: graalvm/setup-graalvm@v1
         with:
-          version: latest
+          distribution: graalvm
           java-version: 17
           cache: sbt
 
       - name: sbt update
-        if: matrix.java == 'graal_latest@17' && steps.setup-graalvm-latest-17.outputs.cache-hit == 'false'
+        if: matrix.java == 'graalvm@17' && steps.setup-java-graalvm-17.outputs.cache-hit == 'false'
+        run: sbt reload +update
+
+      - name: Setup Java (corretto@17)
+        id: setup-java-corretto-17
+        if: matrix.java == 'corretto@17'
+        uses: actions/setup-java@v3
+        with:
+          distribution: corretto
+          java-version: 17
+          cache: sbt
+
+      - name: sbt update
+        if: matrix.java == 'corretto@17' && steps.setup-java-corretto-17.outputs.cache-hit == 'false'
         run: sbt reload +update
 
       - name: Download target directories (2.12, sbt-typelevelJVM)
@@ -302,83 +275,69 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Download Java (temurin@8)
-        id: download-java-temurin-8
-        if: matrix.java == 'temurin@8'
-        uses: typelevel/download-java@v2
-        with:
-          distribution: temurin
-          java-version: 8
-
       - name: Setup Java (temurin@8)
         id: setup-java-temurin-8
         if: matrix.java == 'temurin@8'
         uses: actions/setup-java@v3
         with:
-          distribution: jdkfile
+          distribution: temurin
           java-version: 8
-          jdkFile: ${{ steps.download-java-temurin-8.outputs.jdkFile }}
           cache: sbt
 
       - name: sbt update
         if: matrix.java == 'temurin@8' && steps.setup-java-temurin-8.outputs.cache-hit == 'false'
         run: sbt '++ ${{ matrix.scala }}' reload +update
 
-      - name: Download Java (temurin@11)
-        id: download-java-temurin-11
-        if: matrix.java == 'temurin@11'
-        uses: typelevel/download-java@v2
-        with:
-          distribution: temurin
-          java-version: 11
-
       - name: Setup Java (temurin@11)
         id: setup-java-temurin-11
         if: matrix.java == 'temurin@11'
         uses: actions/setup-java@v3
         with:
-          distribution: jdkfile
+          distribution: temurin
           java-version: 11
-          jdkFile: ${{ steps.download-java-temurin-11.outputs.jdkFile }}
           cache: sbt
 
       - name: sbt update
         if: matrix.java == 'temurin@11' && steps.setup-java-temurin-11.outputs.cache-hit == 'false'
         run: sbt '++ ${{ matrix.scala }}' reload +update
 
-      - name: Download Java (temurin@17)
-        id: download-java-temurin-17
-        if: matrix.java == 'temurin@17'
-        uses: typelevel/download-java@v2
-        with:
-          distribution: temurin
-          java-version: 17
-
       - name: Setup Java (temurin@17)
         id: setup-java-temurin-17
         if: matrix.java == 'temurin@17'
         uses: actions/setup-java@v3
         with:
-          distribution: jdkfile
+          distribution: temurin
           java-version: 17
-          jdkFile: ${{ steps.download-java-temurin-17.outputs.jdkFile }}
           cache: sbt
 
       - name: sbt update
         if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
         run: sbt '++ ${{ matrix.scala }}' reload +update
 
-      - name: Setup GraalVM (graal_latest@17)
-        id: setup-graalvm-latest-17
-        if: matrix.java == 'graal_latest@17'
+      - name: Setup Java (graalvm@17)
+        id: setup-java-graalvm-17
+        if: matrix.java == 'graalvm@17'
         uses: graalvm/setup-graalvm@v1
         with:
-          version: latest
+          distribution: graalvm
           java-version: 17
           cache: sbt
 
       - name: sbt update
-        if: matrix.java == 'graal_latest@17' && steps.setup-graalvm-latest-17.outputs.cache-hit == 'false'
+        if: matrix.java == 'graalvm@17' && steps.setup-java-graalvm-17.outputs.cache-hit == 'false'
+        run: sbt '++ ${{ matrix.scala }}' reload +update
+
+      - name: Setup Java (corretto@17)
+        id: setup-java-corretto-17
+        if: matrix.java == 'corretto@17'
+        uses: actions/setup-java@v3
+        with:
+          distribution: corretto
+          java-version: 17
+          cache: sbt
+
+      - name: sbt update
+        if: matrix.java == 'corretto@17' && steps.setup-java-corretto-17.outputs.cache-hit == 'false'
         run: sbt '++ ${{ matrix.scala }}' reload +update
 
       - name: Submit Dependencies
@@ -416,83 +375,69 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Download Java (temurin@8)
-        id: download-java-temurin-8
-        if: matrix.java == 'temurin@8'
-        uses: typelevel/download-java@v2
-        with:
-          distribution: temurin
-          java-version: 8
-
       - name: Setup Java (temurin@8)
         id: setup-java-temurin-8
         if: matrix.java == 'temurin@8'
         uses: actions/setup-java@v3
         with:
-          distribution: jdkfile
+          distribution: temurin
           java-version: 8
-          jdkFile: ${{ steps.download-java-temurin-8.outputs.jdkFile }}
           cache: sbt
 
       - name: sbt update
         if: matrix.java == 'temurin@8' && steps.setup-java-temurin-8.outputs.cache-hit == 'false'
         run: sbt reload +update
 
-      - name: Download Java (temurin@11)
-        id: download-java-temurin-11
-        if: matrix.java == 'temurin@11'
-        uses: typelevel/download-java@v2
-        with:
-          distribution: temurin
-          java-version: 11
-
       - name: Setup Java (temurin@11)
         id: setup-java-temurin-11
         if: matrix.java == 'temurin@11'
         uses: actions/setup-java@v3
         with:
-          distribution: jdkfile
+          distribution: temurin
           java-version: 11
-          jdkFile: ${{ steps.download-java-temurin-11.outputs.jdkFile }}
           cache: sbt
 
       - name: sbt update
         if: matrix.java == 'temurin@11' && steps.setup-java-temurin-11.outputs.cache-hit == 'false'
         run: sbt reload +update
 
-      - name: Download Java (temurin@17)
-        id: download-java-temurin-17
-        if: matrix.java == 'temurin@17'
-        uses: typelevel/download-java@v2
-        with:
-          distribution: temurin
-          java-version: 17
-
       - name: Setup Java (temurin@17)
         id: setup-java-temurin-17
         if: matrix.java == 'temurin@17'
         uses: actions/setup-java@v3
         with:
-          distribution: jdkfile
+          distribution: temurin
           java-version: 17
-          jdkFile: ${{ steps.download-java-temurin-17.outputs.jdkFile }}
           cache: sbt
 
       - name: sbt update
         if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
         run: sbt reload +update
 
-      - name: Setup GraalVM (graal_latest@17)
-        id: setup-graalvm-latest-17
-        if: matrix.java == 'graal_latest@17'
+      - name: Setup Java (graalvm@17)
+        id: setup-java-graalvm-17
+        if: matrix.java == 'graalvm@17'
         uses: graalvm/setup-graalvm@v1
         with:
-          version: latest
+          distribution: graalvm
           java-version: 17
           cache: sbt
 
       - name: sbt update
-        if: matrix.java == 'graal_latest@17' && steps.setup-graalvm-latest-17.outputs.cache-hit == 'false'
+        if: matrix.java == 'graalvm@17' && steps.setup-java-graalvm-17.outputs.cache-hit == 'false'
+        run: sbt reload +update
+
+      - name: Setup Java (corretto@17)
+        id: setup-java-corretto-17
+        if: matrix.java == 'corretto@17'
+        uses: actions/setup-java@v3
+        with:
+          distribution: corretto
+          java-version: 17
+          cache: sbt
+
+      - name: sbt update
+        if: matrix.java == 'corretto@17' && steps.setup-java-corretto-17.outputs.cache-hit == 'false'
         run: sbt reload +update
 
       - name: Generate site

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -15,7 +15,8 @@ pull_request_rules:
   - status-success=Build and Test (ubuntu-latest, 2.12, temurin@8, sbt-typelevelJVM)
   - status-success=Build and Test (ubuntu-latest, 2.12, temurin@11, sbt-typelevelJVM)
   - status-success=Build and Test (ubuntu-latest, 2.12, temurin@17, sbt-typelevelJVM)
-  - status-success=Build and Test (ubuntu-latest, 2.12, graal_latest@17, sbt-typelevelJVM)
+  - status-success=Build and Test (ubuntu-latest, 2.12, graalvm@17, sbt-typelevelJVM)
+  - status-success=Build and Test (ubuntu-latest, 2.12, corretto@17, sbt-typelevelJVM)
   - status-success=Validate Steward Config (ubuntu-latest)
   - status-success=Generate Site (ubuntu-latest, temurin@8)
   - '#approved-reviews-by>=1'

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,8 @@ ThisBuild / startYear := Some(2022)
 ThisBuild / githubWorkflowJavaVersions ++= Seq(
   JavaSpec.temurin("11"),
   JavaSpec.temurin("17"),
-  JavaSpec(JavaSpec.Distribution.GraalVM("latest"), "17")
+  JavaSpec.graalvm("17"),
+  JavaSpec.corretto("17")
 )
 
 ThisBuild / githubWorkflowPublishTimeoutMinutes := Some(45)

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/JavaSpec.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/JavaSpec.scala
@@ -27,38 +27,20 @@ object JavaSpec {
 
   def temurin(version: String): JavaSpec = JavaSpec(Distribution.Temurin, version)
   def corretto(version: String): JavaSpec = JavaSpec(Distribution.Corretto, version)
-  def graalvm(version: String): JavaSpec = JavaSpec(Distribution.LatestGraalVM, version)
+  def graalvm(version: String): JavaSpec = JavaSpec(Distribution.GraalVM, version)
   def openj9(version: String): JavaSpec = JavaSpec(Distribution.OpenJ9, version)
   def oracle(version: String): JavaSpec = JavaSpec(Distribution.Oracle, version)
 
-  @deprecated(
-    "Use single-arg overload to get the latest GraalVM for a Java version. If you need a specific GraalVM then use JavaSpec(Distribution.GraalVM(graal), version)",
-    "0.4.6"
-  )
-  def graalvm(graal: String, version: String): JavaSpec =
-    JavaSpec(Distribution.GraalVM(graal), version)
-
-  sealed abstract class Distribution(val rendering: String) extends Product with Serializable {
-    private[gha] def isTlIndexed: Boolean = false
-  }
-
-  // marker for distributions in the typelevel jdk index
-  private[gha] sealed abstract class TlDistribution(rendering: String)
-      extends Distribution(rendering) {
-    override def isTlIndexed = true
-  }
+  sealed abstract class Distribution(val rendering: String) extends Product with Serializable
 
   object Distribution {
-    case object Temurin extends TlDistribution("temurin")
-    case object Corretto extends TlDistribution("corretto")
-    case object LatestGraalVM extends TlDistribution("graalvm")
-    case object OpenJ9 extends TlDistribution("openj9")
-    case object Oracle extends TlDistribution("oracle")
-
+    case object Temurin extends Distribution("temurin")
+    case object Corretto extends Distribution("corretto")
+    case object OpenJ9 extends Distribution("openj9")
+    case object Oracle extends Distribution("oracle")
     case object Zulu extends Distribution("zulu")
-    @deprecated("AdoptOpenJDK been transitioned to Adoptium Temurin", "0.4.6")
-    case object Adopt extends Distribution("adopt-hotspot")
     case object Liberica extends Distribution("liberica")
     final case class GraalVM(version: String) extends Distribution(version)
+    case object GraalVM extends Distribution("graalvm")
   }
 }

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/WorkflowStep.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/WorkflowStep.scala
@@ -49,12 +49,15 @@ object WorkflowStep {
         cond = Some(s"$cond && steps.${setupId}.outputs.cache-hit == 'false'")
       )
 
+    val SetupJavaAction = UseRef.Public("actions", "setup-java", "v3")
+    val SetupGraalVMAction = UseRef.Public("graalvm", "setup-graalvm", "v1")
+
     versions flatMap {
       case jv @ JavaSpec(JavaSpec.Distribution.GraalVM(graalVersion), javaVersion) =>
         val setupId = s"setup-graalvm-${graalVersion}-$javaVersion"
         val cond = s"matrix.java == '${jv.render}'"
         WorkflowStep.Use(
-          UseRef.Public("graalvm", "setup-graalvm", "v1"),
+          SetupGraalVMAction,
           name = Some(s"Setup GraalVM (${jv.render})"),
           id = Some(setupId),
           cond = Some(cond),
@@ -62,38 +65,12 @@ object WorkflowStep {
             Map("version" -> graalVersion, "java-version" -> javaVersion, "cache" -> "sbt")
         ) :: sbtUpdateStep(cond, setupId) :: Nil
 
-      case jv @ JavaSpec(dist, version) if dist.isTlIndexed =>
-        val cond = s"matrix.java == '${jv.render}'"
-        val downloadId = s"download-java-${dist.rendering}-$version"
-        val setupId = s"setup-java-${dist.rendering}-$version"
-        List(
-          WorkflowStep.Use(
-            UseRef.Public("typelevel", "download-java", "v2"),
-            name = Some(s"Download Java (${jv.render})"),
-            id = Some(downloadId),
-            cond = Some(cond),
-            params = Map("distribution" -> dist.rendering, "java-version" -> version)
-          ),
-          WorkflowStep.Use(
-            UseRef.Public("actions", "setup-java", "v3"),
-            name = Some(s"Setup Java (${jv.render})"),
-            id = Some(setupId),
-            cond = Some(cond),
-            params = Map(
-              "distribution" -> "jdkfile",
-              "java-version" -> version,
-              "jdkFile" -> s"$${{ steps.$downloadId.outputs.jdkFile }}",
-              "cache" -> "sbt"
-            )
-          ),
-          sbtUpdateStep(cond, setupId)
-        )
-
       case jv @ JavaSpec(dist, version) =>
         val setupId = s"setup-java-${dist.rendering}-$version"
         val cond = s"matrix.java == '${jv.render}'"
+
         WorkflowStep.Use(
-          UseRef.Public("actions", "setup-java", "v3"),
+          if (dist == JavaSpec.Distribution.GraalVM) SetupGraalVMAction else SetupJavaAction,
           name = Some(s"Setup Java (${jv.render})"),
           id = Some(setupId),
           cond = Some(cond),


### PR DESCRIPTION
1. We no longer use the typelevel/jdk-index. setup-java now includes all the JVMs we care about and overall seems well-maintained. I no longer think it's worth the effort to maintain our own index.

2. Closes https://github.com/typelevel/sbt-typelevel/issues/526. GraalVM now behaves like an ordinary Java distribution (i.e. it no longer has independent versioning).