### PR TITLE
Make `s01.oss.sonatype.org` the default host

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -27,7 +27,7 @@ Instead of using the super-plugins, for finer-grained control you can always add
 ### sbt-typelevel-sonatype
 - `TypelevelSonatypePlugin`: Sets up publishing to Sonatype/Maven.
 - `tlRelease` (command): check binary-compatibility and `+publish` to Sonatype
-- `tlSonatypeUseLegacyHost` (setting): publish to `oss.sonatype.org` instead of `s01.oss.sonatype.org` (default: true)
+- `tlSonatypeUseLegacyHost` (setting): publish to `oss.sonatype.org` instead of `s01.oss.sonatype.org` (default: false)
 
 ### sbt-typelevel-settings
 - `TypelevelSettingsPlugin`: Good and/or opinionated defaults for scalac settings etc., inspired by sbt-tpolecat.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -87,9 +87,12 @@ val root = tlCrossRootProject
   .aggregate(core, io, node, scodec, protocols, reactiveStreams, benchmark)
 ```
 
-## How do I publish to `s01.oss.sonatype.org`?
+## How do I publish to `oss.sonatype.org` instead of `s01.oss.sonatype.org`?
+
+Note that `oss.sonatype.org` is the legacy host and there is an [open invitation to migrate to the new host](https://central.sonatype.org/news/20210223_new-users-on-s01/#why-are-we-doing-this).
+
 ```scala
-ThisBuild / tlSonatypeUseLegacyHost := false
+ThisBuild / tlSonatypeUseLegacyHost := true
 ```
 
 ## How do I publish a website like this one?

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,8 +78,8 @@ ThisBuild / developers := List(
   tlGitHubDev("armanbilge", "Arman Bilge")
 )
 
-// true by default, set to false to publish to s01.oss.sonatype.org
-ThisBuild / tlSonatypeUseLegacyHost := true
+// false by default, set to true to publish to oss.sonatype.org
+ThisBuild / tlSonatypeUseLegacyHost := false
 
 val Scala213 = "2.13.8"
 ThisBuild / crossScalaVersions := Seq(Scala213, "3.1.1")

--- a/sonatype/src/main/scala/org/typelevel/sbt/TypelevelSonatypePlugin.scala
+++ b/sonatype/src/main/scala/org/typelevel/sbt/TypelevelSonatypePlugin.scala
@@ -32,7 +32,7 @@ object TypelevelSonatypePlugin extends AutoPlugin {
 
   object autoImport {
     lazy val tlSonatypeUseLegacyHost =
-      settingKey[Boolean]("Publish to oss.sonatype.org instead of s01 (default: true)")
+      settingKey[Boolean]("Publish to oss.sonatype.org instead of s01 (default: false)")
   }
 
   import autoImport._


### PR DESCRIPTION
I accidentally pushed 8912ce0c6b732e06cb3a3a03a763bd618c47ba28 directly to `main` 🙃 

Anyway, this PR provides notice and updates the docs. Typelevel itself has migrated to the new host, all newly registered group ids are using it, it's easy to migrate by opening an issue on the Sonatype JIRA, and it is still configurable to the old legacy host if needed, including by a global env variable / GHA secret.