### PR TITLE
Better `prePR` command

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -58,7 +58,6 @@ Instead of using the super-plugins, for finer-grained control you can always add
 
 ### sbt-typelevel
 - `TypelevelPlugin`: The super-super-plugin intended for bootstrapping the typical Typelevel project. Sets up CI release including snapshots, scalac settings, headers, and formatting.
-- `tlFatalWarningsInCi` (setting): Convert compiler warnings into errors under CI builds (default: true).
 
 ### sbt-typelevel-site
 -  `TypelevelSitePlugin`: Sets up an [mdoc](https://scalameta.org/mdoc/)/[Laika](https://typelevel.org/Laika/)-generated website, automatically published to GitHub pages in CI.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -44,7 +44,7 @@ You may also want to (globally) install the [sbt-rewarn](https://github.com/rtim
 If you are using **sbt-typelevel** fatal warnings are on by default in CI.
 
 ```scala
-ThisBuild / tlFatalWarningsInCi := false
+ThisBuild / tlFatalWarnings := false
 ```
 
 If you are only using **sbt-typelevel-ci-release**, you are completely in charge of your own `scalacOptions`, including fatal warnings.


### PR DESCRIPTION
We redefine the `prePR` command to hopefully give a better UX.

It now uses the idea from https://github.com/typelevel/sbt-typelevel/pull/210 to dynamically generate the `prePR` command depending on whether headers, scalafmt, and scalafix are enabled.

Closes https://github.com/typelevel/sbt-typelevel/issues/204#issue-1164304486. In that discussion we decided that `prePR` should be restricted to self-fixing things (i.e. headers, scalafmt, and scalafix).

Also closes https://github.com/typelevel/sbt-typelevel/issues/254 by deprecating `tlFatalWarningsInCi`. It no longer has a purpose in the new `prePR` command.