### PR TITLE
Move `noPublishProjectRefs` to always-triggered plugin

### DIFF
--- a/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
@@ -16,7 +16,7 @@
 
 package org.typelevel.sbt
 
-import org.typelevel.sbt.NoPublishPlugin.autoImport._
+import org.typelevel.sbt.NoPublishGlobalPlugin.autoImport._
 import org.typelevel.sbt.gha.GenerativePlugin
 import org.typelevel.sbt.gha.GenerativePlugin.autoImport._
 import org.typelevel.sbt.gha.GitHubActionsPlugin

--- a/no-publish/src/main/scala/org/typelevel/sbt/NoPublishPlugin.scala
+++ b/no-publish/src/main/scala/org/typelevel/sbt/NoPublishPlugin.scala
@@ -19,22 +19,11 @@ package org.typelevel.sbt
 import sbt._
 
 import Keys._
+import NoPublishGlobalPlugin.noPublishInternalAggregation
 
 object NoPublishPlugin extends AutoPlugin {
-  object autoImport {
-    lazy val noPublishProjectRefs = settingKey[Seq[ProjectRef]]("List of no-publish projects")
-  }
-  import autoImport._
-
-  private lazy val noPublishInternalAggregation =
-    settingKey[Seq[ProjectRef]]("Aggregates all the no-publish projects")
 
   override def trigger = noTrigger
-
-  override def globalSettings = Seq(
-    noPublishInternalAggregation := Seq(),
-    noPublishProjectRefs := noPublishInternalAggregation.value
-  )
 
   override def projectSettings = Seq(
     publish := {},
@@ -43,4 +32,25 @@ object NoPublishPlugin extends AutoPlugin {
     publish / skip := true,
     Global / noPublishInternalAggregation += thisProjectRef.value
   )
+}
+
+object NoPublishGlobalPlugin extends AutoPlugin {
+
+  // triggered even if NoPublishPlugin is not used in the build
+  override def trigger = allRequirements
+
+  object autoImport {
+    lazy val noPublishProjectRefs = settingKey[Seq[ProjectRef]]("List of no-publish projects")
+  }
+
+  import autoImport._
+
+  private[sbt] lazy val noPublishInternalAggregation =
+    settingKey[Seq[ProjectRef]]("Aggregates all the no-publish projects")
+
+  override def globalSettings = Seq(
+    noPublishInternalAggregation := Seq(),
+    noPublishProjectRefs := noPublishInternalAggregation.value
+  )
+
 }


### PR DESCRIPTION
The `noPublishProjectRefs` setting should always be available, even if the `NoPublishPlugin` is not used in the build (in which case `noPublishProjectRefs` is empty).

So we move the setting to its own plugin which is guaranteed to be triggered for every build, even builds that do not use `NoPublishPlugin`.