### PR TITLE
Corrected stale 2.13 version in WorkflowJob

### DIFF
--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/WorkflowJob.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/WorkflowJob.scala
@@ -24,7 +24,7 @@ final case class WorkflowJob(
     cond: Option[String] = None,
     env: Map[String, String] = Map(),
     oses: List[String] = List("ubuntu-latest"),
-    scalas: List[String] = List("2.13.6"),
+    scalas: List[String] = List("2.13.11"),
     javas: List[JavaSpec] = List(JavaSpec.temurin("11")),
     needs: List[String] = List(),
     matrixFailFast: Option[Boolean] = None,

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/WorkflowJob.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/WorkflowJob.scala
@@ -24,7 +24,7 @@ final case class WorkflowJob(
     cond: Option[String] = None,
     env: Map[String, String] = Map(),
     oses: List[String] = List("ubuntu-latest"),
-    scalas: List[String] = List("2.13.11"),
+    scalas: List[String] = List("2.13"),
     javas: List[JavaSpec] = List(JavaSpec.temurin("11")),
     needs: List[String] = List(),
     matrixFailFast: Option[Boolean] = None,


### PR DESCRIPTION
Bumps 2.13.6 default to ~~2.13.11~~ 2.13 (matching the behaviour of the generalisation to binary versions). Feel free to close if this is not desired!