### PR TITLE
New light theme for `sbt-typelevel-site`!

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,7 +2,7 @@
 
 ## How do I cut a release?
 
-Create a release on GitHub with a v-prefixed, semantically-versioned tag (or, tag a commit locally and push to GitHub). This will start a CI release. Example tags: `v0.4.2`, `v1.2.3`, `v1.0.0-M1`, `v1.2.0-RC2`. 
+Create a release on GitHub with a v-prefixed, semantically-versioned tag (or, tag a commit locally and push to GitHub). This will start a CI release. Example tags: `v0.4.2`, `v1.2.3`, `v1.0.0-M1`, `v1.2.0-RC2`.
 
 It is also possible to run the release process entirely locally by invoking the `tlRelease` command, assuming that you have correctly configured your PGP keys and Sonatype credentials.
 

--- a/site/src/main/scala/org/typelevel/sbt/site/TypelevelSiteSettings.scala
+++ b/site/src/main/scala/org/typelevel/sbt/site/TypelevelSiteSettings.scala
@@ -68,9 +68,9 @@ object TypelevelSiteSettings {
   val offWhiteTl = Color.hex("f2f3f4")
   // Extra colours to supplement
   val lightPink = Color.hex("ffe7e7")
-  val lightPinkGrey = Color.hex("f7f3f3") //f6f0f0
+  val lightPinkGrey = Color.hex("f7f3f3") // f6f0f0
   val slateBlue = Color.hex("335C67")
-  val lightSlateBlue = Color.hex("ddeaed") //cce0e4
+  val lightSlateBlue = Color.hex("ddeaed") // cce0e4
   val softYellow = Color.hex("f9f5d9") // f3eab2
 
   val defaults: Initialize[Helium] = setting {

--- a/site/src/main/scala/org/typelevel/sbt/site/TypelevelSiteSettings.scala
+++ b/site/src/main/scala/org/typelevel/sbt/site/TypelevelSiteSettings.scala
@@ -22,6 +22,7 @@ import laika.ast.Span
 import laika.ast.TemplateString
 import laika.helium.Helium
 import laika.helium.config._
+import laika.theme.config.Color
 import org.typelevel.sbt.TypelevelGitHubPlugin.gitHubUserRepo
 import sbt.Def._
 import sbt.Keys.licenses
@@ -55,6 +56,22 @@ object TypelevelSiteSettings {
     Favicon.external("https://typelevel.org/img/favicon.png", "32x32", "image/png")
   )
 
+  // light theme colours
+  // Tl suffix indicates these are lifted directly from somewhere within the Typelevel site
+  val redTl = Color.hex("f8293a")
+  val brightRedTl = Color.hex("fe4559")
+  val coralTl = Color.hex("f86971")
+  val pinkTl = Color.hex("ffb4b5")
+  val whiteTl = Color.hex("ffffff")
+  val gunmetalTl = Color.hex("21303f")
+  val platinumTl = Color.hex("e6e8ea") //e2e4e6?
+  val offWhiteTl = Color.hex("f2f3f4")
+  // Extra colours to supplement
+  val lightPinkGrey = Color.hex("f9eded") // was ffe7e7 (Arman liked this one)
+  val slateBlue = Color.hex("335C67")
+  val lightSlateBlue = Color.hex("9ac2c9")
+  val softYellow = Color.hex("f3eab2")
+
   val defaults: Initialize[Helium] = setting {
     GenericSiteSettings
       .defaults
@@ -74,6 +91,23 @@ object TypelevelSiteSettings {
       .topNavigationBar(
         homeLink = defaultHomeLink,
         navLinks = List(chatLink, mastodonLink)
+      )
+      .site.themeColors(
+        primary = brightRedTl,
+        secondary = slateBlue,
+        primaryMedium = coralTl,
+        primaryLight = lightPinkGrey,
+        text = gunmetalTl,
+        background = whiteTl,
+        bgGradient = (platinumTl, offWhiteTl)
+      )
+      .site.messageColors(
+        info = slateBlue,
+        infoLight = lightSlateBlue,
+        warning = slateBlue,
+        warningLight = softYellow,
+        error = slateBlue,
+        errorLight = pinkTl,
       )
   }
 

--- a/site/src/main/scala/org/typelevel/sbt/site/TypelevelSiteSettings.scala
+++ b/site/src/main/scala/org/typelevel/sbt/site/TypelevelSiteSettings.scala
@@ -70,7 +70,7 @@ object TypelevelSiteSettings {
   val lightPinkGrey = Color.hex("f9eded") // was ffe7e7 (Arman liked this one)
   val slateBlue = Color.hex("335C67")
   val lightSlateBlue = Color.hex("9ac2c9")
-  val softYellow = Color.hex("f3eab2")
+  val softYellow = Color.hex("f7f0c8") //f3eab2
 
   val defaults: Initialize[Helium] = setting {
     GenericSiteSettings

--- a/site/src/main/scala/org/typelevel/sbt/site/TypelevelSiteSettings.scala
+++ b/site/src/main/scala/org/typelevel/sbt/site/TypelevelSiteSettings.scala
@@ -67,10 +67,11 @@ object TypelevelSiteSettings {
   val platinumTl = Color.hex("e6e8ea") // e2e4e6?
   val offWhiteTl = Color.hex("f2f3f4")
   // Extra colours to supplement
-  val lightPinkGrey = Color.hex("f6f0f0") // was ffe7e7 (Arman liked this one)
+  val lightPink = Color.hex("ffe7e7")
+  val lightPinkGrey = Color.hex("f7f3f3") //f6f0f0
   val slateBlue = Color.hex("335C67")
-  val lightSlateBlue = Color.hex("9ac2c9")
-  val softYellow = Color.hex("f7f0c8") // f3eab2
+  val lightSlateBlue = Color.hex("ddeaed") //cce0e4
+  val softYellow = Color.hex("f9f5d9") // f3eab2
 
   val defaults: Initialize[Helium] = setting {
     GenericSiteSettings
@@ -94,7 +95,7 @@ object TypelevelSiteSettings {
       )
       .site
       .themeColors(
-        primary = brightRedTl,
+        primary = redTl,
         secondary = slateBlue,
         primaryMedium = coralTl,
         primaryLight = lightPinkGrey,
@@ -109,7 +110,7 @@ object TypelevelSiteSettings {
         warning = slateBlue,
         warningLight = softYellow,
         error = slateBlue,
-        errorLight = pinkTl
+        errorLight = lightPink
       )
       .site
       .syntaxHighlightingColors(

--- a/site/src/main/scala/org/typelevel/sbt/site/TypelevelSiteSettings.scala
+++ b/site/src/main/scala/org/typelevel/sbt/site/TypelevelSiteSettings.scala
@@ -67,7 +67,7 @@ object TypelevelSiteSettings {
   val platinumTl = Color.hex("e6e8ea") //e2e4e6?
   val offWhiteTl = Color.hex("f2f3f4")
   // Extra colours to supplement
-  val lightPinkGrey = Color.hex("f9eded") // was ffe7e7 (Arman liked this one)
+  val lightPinkGrey = Color.hex("f6f0f0") // was ffe7e7 (Arman liked this one)
   val slateBlue = Color.hex("335C67")
   val lightSlateBlue = Color.hex("9ac2c9")
   val softYellow = Color.hex("f7f0c8") //f3eab2
@@ -108,6 +108,22 @@ object TypelevelSiteSettings {
         warningLight = softYellow,
         error = slateBlue,
         errorLight = pinkTl,
+      )
+      .site.syntaxHighlightingColors(
+        base = ColorQuintet(
+          gunmetalTl,
+          Color.hex("73a6ad"), // comments
+          Color.hex("b2adb4"), // ?
+          pinkTl,              // identifier
+          platinumTl           // base colour
+        ),
+        wheel = ColorQuintet(
+          Color.hex("8fa1c9"), // substitution, annotation
+          Color.hex("81e67b"), // keyword, escape-sequence
+          Color.hex("ffde6d"), // declaration name
+          Color.hex("759EB8"), // literals
+          coralTl              // type/class name
+        )
       )
   }
 

--- a/site/src/main/scala/org/typelevel/sbt/site/TypelevelSiteSettings.scala
+++ b/site/src/main/scala/org/typelevel/sbt/site/TypelevelSiteSettings.scala
@@ -64,13 +64,13 @@ object TypelevelSiteSettings {
   val pinkTl = Color.hex("ffb4b5")
   val whiteTl = Color.hex("ffffff")
   val gunmetalTl = Color.hex("21303f")
-  val platinumTl = Color.hex("e6e8ea") //e2e4e6?
+  val platinumTl = Color.hex("e6e8ea") // e2e4e6?
   val offWhiteTl = Color.hex("f2f3f4")
   // Extra colours to supplement
   val lightPinkGrey = Color.hex("f6f0f0") // was ffe7e7 (Arman liked this one)
   val slateBlue = Color.hex("335C67")
   val lightSlateBlue = Color.hex("9ac2c9")
-  val softYellow = Color.hex("f7f0c8") //f3eab2
+  val softYellow = Color.hex("f7f0c8") // f3eab2
 
   val defaults: Initialize[Helium] = setting {
     GenericSiteSettings
@@ -92,7 +92,8 @@ object TypelevelSiteSettings {
         homeLink = defaultHomeLink,
         navLinks = List(chatLink, mastodonLink)
       )
-      .site.themeColors(
+      .site
+      .themeColors(
         primary = brightRedTl,
         secondary = slateBlue,
         primaryMedium = coralTl,
@@ -101,28 +102,30 @@ object TypelevelSiteSettings {
         background = whiteTl,
         bgGradient = (platinumTl, offWhiteTl)
       )
-      .site.messageColors(
+      .site
+      .messageColors(
         info = slateBlue,
         infoLight = lightSlateBlue,
         warning = slateBlue,
         warningLight = softYellow,
         error = slateBlue,
-        errorLight = pinkTl,
+        errorLight = pinkTl
       )
-      .site.syntaxHighlightingColors(
+      .site
+      .syntaxHighlightingColors(
         base = ColorQuintet(
           gunmetalTl,
           Color.hex("73a6ad"), // comments
           Color.hex("b2adb4"), // ?
-          pinkTl,              // identifier
-          platinumTl           // base colour
+          pinkTl, // identifier
+          platinumTl // base colour
         ),
         wheel = ColorQuintet(
           Color.hex("8fa1c9"), // substitution, annotation
           Color.hex("81e67b"), // keyword, escape-sequence
           Color.hex("ffde6d"), // declaration name
           Color.hex("759EB8"), // literals
-          coralTl              // type/class name
+          coralTl // type/class name
         )
       )
   }


### PR DESCRIPTION
Changed the default Helium theme over to one more clearly embodying the typelevel colours as found on the main website. Reworked the colours and syntax highlighting. Colours taken from typelevel are clearly labelled as such.

Here is an example:

![image](https://github.com/typelevel/sbt-typelevel/assets/5148976/69c334bd-c898-4e00-87e6-33c04ea70a2e)
