### PR TITLE
javadoc.io now supports sbt plugins

### DIFF
--- a/sonatype/src/main/scala/org/typelevel/sbt/TypelevelSonatypePlugin.scala
+++ b/sonatype/src/main/scala/org/typelevel/sbt/TypelevelSonatypePlugin.scala
@@ -72,8 +72,8 @@ object TypelevelSonatypePlugin extends AutoPlugin {
     Def.setting(javadocioUrl.value.orElse(sonatypeApiUrl.value))
 
   private lazy val javadocioUrl = Def.setting {
-    if (isSnapshot.value || sbtPlugin.value || !publishArtifact.value)
-      None // javadoc.io doesn't support snapshots, sbt plugins, or unpublished modules ;)
+    if (isSnapshot.value || !publishArtifact.value)
+      None // javadoc.io doesn't support snapshots, or unpublished modules ;)
     else
       CrossVersion(
         crossVersion.value,


### PR DESCRIPTION
Or more correctly, sbt plugins support Maven properly, so javadoc.io can pick up our docs and publish them.