### PR TITLE
New Theme Inversion

### DIFF
--- a/site/src/main/scala/org/typelevel/sbt/site/TypelevelSiteSettings.scala
+++ b/site/src/main/scala/org/typelevel/sbt/site/TypelevelSiteSettings.scala
@@ -26,6 +26,7 @@ import laika.theme.config.Color
 import org.typelevel.sbt.TypelevelGitHubPlugin.gitHubUserRepo
 import sbt.Def._
 import sbt.Keys.licenses
+import laika.ast.Path.Root
 
 object TypelevelSiteSettings {
 
@@ -58,20 +59,27 @@ object TypelevelSiteSettings {
 
   // light theme colours
   // Tl suffix indicates these are lifted directly from somewhere within the Typelevel site
-  val redTl = Color.hex("f8293a")
+  //val redTl = Color.hex("f8293a")
   val brightRedTl = Color.hex("fe4559")
   val coralTl = Color.hex("f86971")
   val pinkTl = Color.hex("ffb4b5")
   val whiteTl = Color.hex("ffffff")
   val gunmetalTl = Color.hex("21303f")
   val platinumTl = Color.hex("e6e8ea") // e2e4e6?
-  val offWhiteTl = Color.hex("f2f3f4")
+  //val offWhiteTl = Color.hex("f2f3f4")
   // Extra colours to supplement
   val lightPink = Color.hex("ffe7e7")
-  val lightPinkGrey = Color.hex("f7f3f3") // f6f0f0
+  //val lightPinkGrey = Color.hex("f7f3f3")
+  //val lightPinkGreyButDarker = Color.hex("efe7e7")
   val slateBlue = Color.hex("335C67")
-  val lightSlateBlue = Color.hex("ddeaed") // cce0e4
+  val mediumSlateBlue = Color.hex("b0cfd8")
+  val lightSlateBlue = Color.hex("ddeaed")
+  val lighterSlateBlue = Color.hex("f4f8fa")
   val softYellow = Color.hex("f9f5d9") // f3eab2
+
+  val interimBlueDark = Color.hex("385a70")
+  val interimBlueMedium = Color.hex("406881")
+  val interimBlueLight = Color.hex("487692")
 
   val defaults: Initialize[Helium] = setting {
     GenericSiteSettings
@@ -95,21 +103,24 @@ object TypelevelSiteSettings {
       )
       .site
       .themeColors(
-        primary = redTl,
-        secondary = slateBlue,
-        primaryMedium = coralTl,
-        primaryLight = lightPinkGrey,
+        primary = interimBlueDark,
+        secondary = brightRedTl,
+        // the medium is on slate until the landing page is decoupled
+        primaryMedium = lightSlateBlue, // will be when the landing page text is decoupled mediumSlateBlue
+        primaryLight = lighterSlateBlue,
         text = gunmetalTl,
         background = whiteTl,
-        bgGradient = (platinumTl, offWhiteTl)
+        // interim colours, while we wait for light gradient support on landing pages
+        //bgGradient = (mediumSlateBlue, lighterSlateBlue)
+        bgGradient = (interimBlueMedium, interimBlueLight)
       )
       .site
       .messageColors(
-        info = slateBlue,
+        info = interimBlueDark,
         infoLight = lightSlateBlue,
-        warning = slateBlue,
+        warning = interimBlueDark,
         warningLight = softYellow,
-        error = slateBlue,
+        error = interimBlueDark,
         errorLight = lightPink
       )
       .site
@@ -129,6 +140,41 @@ object TypelevelSiteSettings {
           coralTl // type/class name
         )
       )
+    // just for testing purposes :) this can be removed later when things are finalised
+    /*.site.landingPage(
+    logo = Some(Image.external(s"https://typelevel.org/img/logo.svg")),
+    title = Some("SBT Typelevel"),
+    subtitle = Some("Build Configuration, Done Better than Yesterday?"),
+    latestReleases = Seq(
+      ReleaseInfo("Latest Stable Release", "0.4.23"),
+      ReleaseInfo("Latest Milestone Release", "0.5.0-M5")
+    ),
+    license = Some("Apache 2.0"),
+    titleLinks = Seq(
+      VersionMenu.create(unversionedLabel = "Getting Started"),
+      LinkGroup.create(
+        IconLink.external("https://github.com/abcdefg/", HeliumIcon.github),
+        IconLink.external("https://gitter.im/abcdefg/", HeliumIcon.chat),
+        IconLink.external("https://twitter.com/abcdefg/", HeliumIcon.twitter)
+      )
+    ),
+    documentationLinks = Seq(
+      TextLink.internal(Root / "site.md", "sbt-typelevel-site"),
+      TextLink.internal(Root / "index_.md", "home")
+    ),
+    projectLinks = Seq(
+      TextLink.internal(Root / "site.md", "Text Link"),
+      ButtonLink.external("http://somewhere.com/", "Button Label"),
+      LinkGroup.create(
+        IconLink.internal(Root / "site.md", HeliumIcon.demo),
+        IconLink.internal(Root / "site.md", HeliumIcon.info)
+      )
+    ),
+    teasers = Seq(
+      Teaser("Teaser 1", "Description 1"),
+      Teaser("Teaser 2", "Description 2"),
+      Teaser("Teaser 3", "Description 3")
+    ))*/
   }
 
 }

--- a/site/src/main/scala/org/typelevel/sbt/site/TypelevelSiteSettings.scala
+++ b/site/src/main/scala/org/typelevel/sbt/site/TypelevelSiteSettings.scala
@@ -64,17 +64,15 @@ object TypelevelSiteSettings {
   val pinkTl = Color.hex("ffb4b5")
   val whiteTl = Color.hex("ffffff")
   val gunmetalTl = Color.hex("21303f")
-  val platinumTl = Color.hex("e6e8ea") // e2e4e6?
-  // val offWhiteTl = Color.hex("f2f3f4")
+  val platinumTl = Color.hex("e6e8ea")
   // Extra colours to supplement
   val lightPink = Color.hex("ffe7e7")
-  // val lightPinkGrey = Color.hex("f7f3f3")
-  // val lightPinkGreyButDarker = Color.hex("efe7e7")
-  val slateBlue = Color.hex("385a70") // 406881
+  val slateBlue = Color.hex("385a70") // 406881 (original slateCyan)
+  val mediumSlateCyanButDarker = Color.hex("8ebac7")
   val mediumSlateCyan = Color.hex("b0cfd8")
   val lightSlateCyan = Color.hex("ddeaed")
   val lighterSlateCyan = Color.hex("f4f8fa")
-  val softYellow = Color.hex("f9f5d9") // f3eab2
+  val softYellow = Color.hex("f9f5d9")
 
   val defaults: Initialize[Helium] = setting {
     GenericSiteSettings
@@ -100,7 +98,7 @@ object TypelevelSiteSettings {
       .themeColors(
         primary = slateBlue,
         secondary = brightRedTl,
-        primaryMedium = mediumSlateCyan,
+        primaryMedium = mediumSlateCyanButDarker,
         primaryLight = lighterSlateCyan,
         text = gunmetalTl,
         background = whiteTl,
@@ -119,7 +117,7 @@ object TypelevelSiteSettings {
       .syntaxHighlightingColors(
         base = ColorQuintet(
           gunmetalTl,
-          Color.hex("73a6ad"), // comments
+          Color.hex("73ad9b"), // comments
           Color.hex("b2adb4"), // ?
           pinkTl, // identifier
           platinumTl // base colour
@@ -128,7 +126,7 @@ object TypelevelSiteSettings {
           Color.hex("8fa1c9"), // substitution, annotation
           Color.hex("81e67b"), // keyword, escape-sequence
           Color.hex("ffde6d"), // declaration name
-          Color.hex("759EB8"), // literals
+          Color.hex("86aac1"), // literals
           coralTl // type/class name
         )
       )

--- a/site/src/main/scala/org/typelevel/sbt/site/TypelevelSiteSettings.scala
+++ b/site/src/main/scala/org/typelevel/sbt/site/TypelevelSiteSettings.scala
@@ -26,7 +26,7 @@ import laika.theme.config.Color
 import org.typelevel.sbt.TypelevelGitHubPlugin.gitHubUserRepo
 import sbt.Def._
 import sbt.Keys.licenses
-import laika.ast.Path.Root
+//import laika.ast.Path.Root
 
 object TypelevelSiteSettings {
 
@@ -59,18 +59,18 @@ object TypelevelSiteSettings {
 
   // light theme colours
   // Tl suffix indicates these are lifted directly from somewhere within the Typelevel site
-  //val redTl = Color.hex("f8293a")
+  // val redTl = Color.hex("f8293a")
   val brightRedTl = Color.hex("fe4559")
   val coralTl = Color.hex("f86971")
   val pinkTl = Color.hex("ffb4b5")
   val whiteTl = Color.hex("ffffff")
   val gunmetalTl = Color.hex("21303f")
   val platinumTl = Color.hex("e6e8ea") // e2e4e6?
-  //val offWhiteTl = Color.hex("f2f3f4")
+  // val offWhiteTl = Color.hex("f2f3f4")
   // Extra colours to supplement
   val lightPink = Color.hex("ffe7e7")
-  //val lightPinkGrey = Color.hex("f7f3f3")
-  //val lightPinkGreyButDarker = Color.hex("efe7e7")
+  // val lightPinkGrey = Color.hex("f7f3f3")
+  // val lightPinkGreyButDarker = Color.hex("efe7e7")
   val slateBlue = Color.hex("335C67")
   val mediumSlateBlue = Color.hex("b0cfd8")
   val lightSlateBlue = Color.hex("ddeaed")
@@ -105,13 +105,13 @@ object TypelevelSiteSettings {
       .themeColors(
         primary = interimBlueDark,
         secondary = brightRedTl,
-        // the medium is on slate until the landing page is decoupled
-        primaryMedium = lightSlateBlue, // will be when the landing page text is decoupled mediumSlateBlue
+        // the medium is on slate until the landing page is decoupled (then mediumSlateBlue)
+        primaryMedium = lightSlateBlue,
         primaryLight = lighterSlateBlue,
         text = gunmetalTl,
         background = whiteTl,
         // interim colours, while we wait for light gradient support on landing pages
-        //bgGradient = (mediumSlateBlue, lighterSlateBlue)
+        // bgGradient = (mediumSlateBlue, lighterSlateBlue)
         bgGradient = (interimBlueMedium, interimBlueLight)
       )
       .site

--- a/site/src/main/scala/org/typelevel/sbt/site/TypelevelSiteSettings.scala
+++ b/site/src/main/scala/org/typelevel/sbt/site/TypelevelSiteSettings.scala
@@ -26,7 +26,6 @@ import laika.theme.config.Color
 import org.typelevel.sbt.TypelevelGitHubPlugin.gitHubUserRepo
 import sbt.Def._
 import sbt.Keys.licenses
-//import laika.ast.Path.Root
 
 object TypelevelSiteSettings {
 
@@ -71,15 +70,11 @@ object TypelevelSiteSettings {
   val lightPink = Color.hex("ffe7e7")
   // val lightPinkGrey = Color.hex("f7f3f3")
   // val lightPinkGreyButDarker = Color.hex("efe7e7")
-  val slateBlue = Color.hex("335C67")
-  val mediumSlateBlue = Color.hex("b0cfd8")
-  val lightSlateBlue = Color.hex("ddeaed")
-  val lighterSlateBlue = Color.hex("f4f8fa")
+  val slateBlue = Color.hex("385a70") // 406881
+  val mediumSlateCyan = Color.hex("b0cfd8")
+  val lightSlateCyan = Color.hex("ddeaed")
+  val lighterSlateCyan = Color.hex("f4f8fa")
   val softYellow = Color.hex("f9f5d9") // f3eab2
-
-  val interimBlueDark = Color.hex("385a70")
-  val interimBlueMedium = Color.hex("406881")
-  val interimBlueLight = Color.hex("487692")
 
   val defaults: Initialize[Helium] = setting {
     GenericSiteSettings
@@ -103,24 +98,21 @@ object TypelevelSiteSettings {
       )
       .site
       .themeColors(
-        primary = interimBlueDark,
+        primary = slateBlue,
         secondary = brightRedTl,
-        // the medium is on slate until the landing page is decoupled (then mediumSlateBlue)
-        primaryMedium = lightSlateBlue,
-        primaryLight = lighterSlateBlue,
+        primaryMedium = mediumSlateCyan,
+        primaryLight = lighterSlateCyan,
         text = gunmetalTl,
         background = whiteTl,
-        // interim colours, while we wait for light gradient support on landing pages
-        // bgGradient = (mediumSlateBlue, lighterSlateBlue)
-        bgGradient = (interimBlueMedium, interimBlueLight)
+        bgGradient = (mediumSlateCyan, lighterSlateCyan)
       )
       .site
       .messageColors(
-        info = interimBlueDark,
-        infoLight = lightSlateBlue,
-        warning = interimBlueDark,
+        info = slateBlue,
+        infoLight = lightSlateCyan,
+        warning = slateBlue,
         warningLight = softYellow,
-        error = interimBlueDark,
+        error = slateBlue,
         errorLight = lightPink
       )
       .site
@@ -140,41 +132,5 @@ object TypelevelSiteSettings {
           coralTl // type/class name
         )
       )
-    // just for testing purposes :) this can be removed later when things are finalised
-    /*.site.landingPage(
-    logo = Some(Image.external(s"https://typelevel.org/img/logo.svg")),
-    title = Some("SBT Typelevel"),
-    subtitle = Some("Build Configuration, Done Better than Yesterday?"),
-    latestReleases = Seq(
-      ReleaseInfo("Latest Stable Release", "0.4.23"),
-      ReleaseInfo("Latest Milestone Release", "0.5.0-M5")
-    ),
-    license = Some("Apache 2.0"),
-    titleLinks = Seq(
-      VersionMenu.create(unversionedLabel = "Getting Started"),
-      LinkGroup.create(
-        IconLink.external("https://github.com/abcdefg/", HeliumIcon.github),
-        IconLink.external("https://gitter.im/abcdefg/", HeliumIcon.chat),
-        IconLink.external("https://twitter.com/abcdefg/", HeliumIcon.twitter)
-      )
-    ),
-    documentationLinks = Seq(
-      TextLink.internal(Root / "site.md", "sbt-typelevel-site"),
-      TextLink.internal(Root / "index_.md", "home")
-    ),
-    projectLinks = Seq(
-      TextLink.internal(Root / "site.md", "Text Link"),
-      ButtonLink.external("http://somewhere.com/", "Button Label"),
-      LinkGroup.create(
-        IconLink.internal(Root / "site.md", HeliumIcon.demo),
-        IconLink.internal(Root / "site.md", HeliumIcon.info)
-      )
-    ),
-    teasers = Seq(
-      Teaser("Teaser 1", "Description 1"),
-      Teaser("Teaser 2", "Description 2"),
-      Teaser("Teaser 3", "Description 3")
-    ))*/
   }
-
 }


### PR DESCRIPTION
Some people were unapply with the sheer in-your-face redness of the new theme introduced in #573, so this just inverts the primary and secondary colours, creating a bit better of a balance. With this, the lighter red is brought back, which is a bit more soft (but had bad contrast at the small sizes on the nav-bar), and the landing page changes from #586 have been incorporated.

However, the landing page in Laika is not particularly well set-up for light backgrounds, so while we wait for that to be properly decoupled (text colour-wise), there is an _**interim**_ darker landing page (note the button colour on that screenshot has since been altered):

![image](https://github.com/typelevel/sbt-typelevel/assets/5148976/2fca0369-ce72-443d-9a2b-e8692d9226f3)

![image](https://github.com/typelevel/sbt-typelevel/assets/5148976/249313ba-6b76-44fe-afee-de397687a34c)

Obviously, there is no default landing page for SBT typelevel currently, but this means the theme is currently a bit more future proofed. Eventually, the landing page will be lightened and all will be well with the world.