### PR TITLE
Deprecate `tlSkipIrrelevantScalas`

### DIFF
--- a/ci/src/main/scala/org/typelevel/sbt/CrossRootProject.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/CrossRootProject.scala
@@ -18,6 +18,7 @@ package org.typelevel.sbt
 
 import org.typelevel.sbt.gha.GenerativePlugin.autoImport._
 import sbt._
+import Keys._
 
 /**
  * Simultaneously creates a root project, a Scala JVM aggregate project, a Scala.js aggregate
@@ -132,7 +133,8 @@ object CrossRootProject {
     Some((rootProject.all, rootProject.jvm, rootProject.js, rootProject.native))
 
   def apply(id: String): CrossRootProject = new CrossRootProject(
-    Project(id, file(".")),
+    Project(id, file("."))
+      .settings(crossScalaVersions := Nil, scalaVersion := (ThisBuild / scalaVersion).value),
     Project(s"${id}JVM", file(".jvm")),
     Project(s"${id}JS", file(".js")),
     Project(s"${id}Native", file(".native"))

--- a/ci/src/main/scala/org/typelevel/sbt/CrossRootProject.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/CrossRootProject.scala
@@ -18,6 +18,7 @@ package org.typelevel.sbt
 
 import org.typelevel.sbt.gha.GenerativePlugin.autoImport._
 import sbt._
+
 import Keys._
 
 /**

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -13,7 +13,6 @@ Instead of using the super-plugins, for finer-grained control you can always add
 `TypelevelKernelPlugin`
 
 - `tlIsScala3` (setting): `true`, if `scalaVersion` is 3.x.
-- `tlSkipIrrelevantScalas` (setting): `true`, if should `skip` for `scalaVersion` not in `crossScalaVersions`.
 - `tlReplaceCommandAlias` (method): Replace a `addCommandAlias` definition.
 - `tlReleaseLocal` (command): Alias for `+publishLocal`.
 

--- a/mima/src/main/scala/org/typelevel/sbt/TypelevelMimaPlugin.scala
+++ b/mima/src/main/scala/org/typelevel/sbt/TypelevelMimaPlugin.scala
@@ -40,7 +40,6 @@ object TypelevelMimaPlugin extends AutoPlugin {
 
   import autoImport._
   import TypelevelKernelPlugin.autoImport._
-  import TypelevelKernelPlugin.skipIfIrrelevant
 
   override def buildSettings = Seq[Setting[_]](
     tlVersionIntroduced := Map.empty,
@@ -65,11 +64,9 @@ object TypelevelMimaPlugin extends AutoPlugin {
 
   override def projectSettings = Seq[Setting[_]](
     mimaReportBinaryIssues := {
-      if (!publishArtifact.value || (tlSkipIrrelevantScalas.value && (mimaReportBinaryIssues / skip).value))
-        ()
+      if (!publishArtifact.value) ()
       else mimaReportBinaryIssues.value
     },
-    skipIfIrrelevant(mimaReportBinaryIssues),
     tlMimaPreviousVersions := {
       val introduced = tlVersionIntroduced
         .value

--- a/mima/src/main/scala/org/typelevel/sbt/TypelevelMimaPlugin.scala
+++ b/mima/src/main/scala/org/typelevel/sbt/TypelevelMimaPlugin.scala
@@ -39,7 +39,6 @@ object TypelevelMimaPlugin extends AutoPlugin {
   }
 
   import autoImport._
-  import TypelevelKernelPlugin.autoImport._
 
   override def buildSettings = Seq[Setting[_]](
     tlVersionIntroduced := Map.empty,


### PR DESCRIPTION
We learned in https://github.com/typelevel/Laika/pull/451 that setting `crossScalaVersions := Nil` on the root project seems to be the trick to getting weird builds with "holes" to work, instead of this hack that was often broken.