### PR TITLE
Added binary versions to `module-ignore` inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -476,7 +476,7 @@ jobs:
       - name: Submit Dependencies
         uses: scalacenter/sbt-dependency-submission@v2
         with:
-          modules-ignore: sbt-typelevelJVM docs sbt-typelevelNative sbt-typelevel sbt-typelevelJS
+          modules-ignore: sbt-typelevelJVM_2.12 docs_2.12 sbt-typelevelNative_2.12 sbt-typelevelJS_2.12
           configs-ignore: test scala-tool scala-doc-tool
 
   validate-steward:

--- a/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
@@ -148,7 +148,7 @@ object TypelevelCiPlugin extends AutoPlugin {
               steps = githubWorkflowJobSetup.value.toList :+
                 WorkflowStep.DependencySubmission(
                   None,
-                  Some(noPublishProjectRefs.value.toList.map(_.project)),
+                  Some(noPublishModulesIgnore.value.toList),
                   Some(List("test", "scala-tool", "scala-doc-tool")),
                   None
                 ),

--- a/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
@@ -16,7 +16,7 @@
 
 package org.typelevel.sbt
 
-import org.typelevel.sbt.NoPublishGlobalPlugin.autoImport._
+import org.typelevel.sbt.NoPublishGlobalPlugin.noPublishModulesIgnore
 import org.typelevel.sbt.gha.GenerativePlugin
 import org.typelevel.sbt.gha.GenerativePlugin.autoImport._
 import org.typelevel.sbt.gha.GitHubActionsPlugin

--- a/no-publish/src/main/scala/org/typelevel/sbt/NoPublishPlugin.scala
+++ b/no-publish/src/main/scala/org/typelevel/sbt/NoPublishPlugin.scala
@@ -30,10 +30,10 @@ object NoPublishPlugin extends AutoPlugin {
     publishLocal := {},
     publishArtifact := false,
     publish / skip := true,
-    Global / noPublishModulesIgnore ++= crossScalaVersions.value.map { v =>
+    Global / noPublishModulesIgnore ++= crossScalaVersions.value.flatMap { v =>
       // the binary versions are needed for the modules-ignore in Submit Dependencies
       // it's best to pick them up here instead of guessing in the CI plugin
-      s"${thisProjectRef.value.project}_${CrossVersion.binaryScalaVersion(v)}"
+      CrossVersion(crossVersion.value, v, CrossVersion.binaryScalaVersion(v)).map(cross => cross(thisProjectRef.value.project))
     }
   )
 }

--- a/no-publish/src/main/scala/org/typelevel/sbt/NoPublishPlugin.scala
+++ b/no-publish/src/main/scala/org/typelevel/sbt/NoPublishPlugin.scala
@@ -19,7 +19,7 @@ package org.typelevel.sbt
 import sbt._
 
 import Keys._
-import NoPublishGlobalPlugin.autoImport.noPublishModulesIgnore
+import NoPublishGlobalPlugin.noPublishModulesIgnore
 
 object NoPublishPlugin extends AutoPlugin {
 
@@ -45,12 +45,8 @@ object NoPublishGlobalPlugin extends AutoPlugin {
   // triggered even if NoPublishPlugin is not used in the build
   override def trigger = allRequirements
 
-  object autoImport {
-    private[sbt] lazy val noPublishModulesIgnore =
-      settingKey[Seq[String]]("List of no-publish projects and their scala cross-versions")
-  }
-
-  import autoImport._
+  private[sbt] lazy val noPublishModulesIgnore =
+    settingKey[Seq[String]]("List of no-publish projects and their scala cross-versions")
 
   override def globalSettings = Seq(
     noPublishModulesIgnore := Seq()

--- a/no-publish/src/main/scala/org/typelevel/sbt/NoPublishPlugin.scala
+++ b/no-publish/src/main/scala/org/typelevel/sbt/NoPublishPlugin.scala
@@ -33,7 +33,9 @@ object NoPublishPlugin extends AutoPlugin {
     Global / noPublishModulesIgnore ++= crossScalaVersions.value.flatMap { v =>
       // the binary versions are needed for the modules-ignore in Submit Dependencies
       // it's best to pick them up here instead of guessing in the CI plugin
-      CrossVersion(crossVersion.value, v, CrossVersion.binaryScalaVersion(v)).map(cross => cross(thisProjectRef.value.project))
+      CrossVersion(crossVersion.value, v, CrossVersion.binaryScalaVersion(v)).map { cross =>
+        cross(thisProjectRef.value.project)
+      }
     }
   )
 }

--- a/no-publish/src/main/scala/org/typelevel/sbt/NoPublishPlugin.scala
+++ b/no-publish/src/main/scala/org/typelevel/sbt/NoPublishPlugin.scala
@@ -31,9 +31,9 @@ object NoPublishPlugin extends AutoPlugin {
     publishArtifact := false,
     publish / skip := true,
     Global / noPublishModulesIgnore ++= crossScalaVersions.value.map { v =>
-        // the binary versions are needed for the modules-ignore in Submit Dependencies
-        // it's best to pick them up here instead of guessing in the CI plugin
-        s"${thisProjectRef.value.project}_${CrossVersion.binaryScalaVersion(v)}"
+      // the binary versions are needed for the modules-ignore in Submit Dependencies
+      // it's best to pick them up here instead of guessing in the CI plugin
+      s"${thisProjectRef.value.project}_${CrossVersion.binaryScalaVersion(v)}"
     }
   )
 }
@@ -44,13 +44,14 @@ object NoPublishGlobalPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   object autoImport {
-    private[sbt] lazy val noPublishModulesIgnore = settingKey[Seq[String]]("List of no-publish projects and their scala cross-versions")
+    private[sbt] lazy val noPublishModulesIgnore =
+      settingKey[Seq[String]]("List of no-publish projects and their scala cross-versions")
   }
 
   import autoImport._
 
   override def globalSettings = Seq(
-    noPublishModulesIgnore := Seq(),
+    noPublishModulesIgnore := Seq()
   )
 
 }


### PR DESCRIPTION
Added the binary scala suffix to the end of the module names for `Submit Dependencies`. The result of the change can be seen in the CI file. Fixes #597 