### PR TITLE
Added `test-internal` to the ignored configs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,17 +203,17 @@ jobs:
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' doc
 
       - name: Make target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/patch/exclude-test-internal')
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
         shell: bash
         run: mkdir -p github/target github-actions/target kernel/target versioning/target ci-release/target scalafix/target site/target ci-signing/target mergify/target unidoc/target mima/target no-publish/target sonatype/target ci/target sonatype-ci-release/target core/target settings/target project/target
 
       - name: Compress target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/patch/exclude-test-internal')
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
         shell: bash
         run: tar cf targets.tar github/target github-actions/target kernel/target versioning/target ci-release/target scalafix/target site/target ci-signing/target mergify/target unidoc/target mima/target no-publish/target sonatype/target ci/target sonatype-ci-release/target core/target settings/target project/target
 
       - name: Upload target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/patch/exclude-test-internal')
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
         uses: actions/upload-artifact@v3
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.scala }}-${{ matrix.project }}
@@ -222,7 +222,7 @@ jobs:
   publish:
     name: Publish Artifacts
     needs: [build]
-    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/patch/exclude-test-internal')
+    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,17 +203,17 @@ jobs:
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' doc
 
       - name: Make target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/patch/exclude-test-internal')
         shell: bash
         run: mkdir -p github/target github-actions/target kernel/target versioning/target ci-release/target scalafix/target site/target ci-signing/target mergify/target unidoc/target mima/target no-publish/target sonatype/target ci/target sonatype-ci-release/target core/target settings/target project/target
 
       - name: Compress target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/patch/exclude-test-internal')
         shell: bash
         run: tar cf targets.tar github/target github-actions/target kernel/target versioning/target ci-release/target scalafix/target site/target ci-signing/target mergify/target unidoc/target mima/target no-publish/target sonatype/target ci/target sonatype-ci-release/target core/target settings/target project/target
 
       - name: Upload target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/patch/exclude-test-internal')
         uses: actions/upload-artifact@v3
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.scala }}-${{ matrix.project }}
@@ -222,7 +222,7 @@ jobs:
   publish:
     name: Publish Artifacts
     needs: [build]
-    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
+    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/patch/exclude-test-internal')
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -477,7 +477,7 @@ jobs:
         uses: scalacenter/sbt-dependency-submission@v2
         with:
           modules-ignore: sbt-typelevelJVM_2.12 docs_2.12 sbt-typelevelNative_2.12 sbt-typelevelJS_2.12
-          configs-ignore: test scala-tool scala-doc-tool
+          configs-ignore: test scala-tool scala-doc-tool test-internal
 
   validate-steward:
     name: Validate Steward Config

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,6 @@ ThisBuild / mergifyPrRules += MergifyPrRule(
   )
 )
 ThisBuild / mergifyRequiredJobs ++= Seq("validate-steward", "site")
-ThisBuild / tlCiReleaseBranches := Seq("main", "patch/exclude-test-internal") // FIXME: remove!
 
 val MunitVersion = "0.7.29"
 

--- a/build.sbt
+++ b/build.sbt
@@ -44,6 +44,7 @@ ThisBuild / mergifyPrRules += MergifyPrRule(
   )
 )
 ThisBuild / mergifyRequiredJobs ++= Seq("validate-steward", "site")
+ThisBuild / tlCiReleaseBranches := Seq("main", "patch/exclude-test-internal") // FIXME: remove!
 
 val MunitVersion = "0.7.29"
 

--- a/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
@@ -149,7 +149,7 @@ object TypelevelCiPlugin extends AutoPlugin {
                 WorkflowStep.DependencySubmission(
                   None,
                   Some(noPublishModulesIgnore.value.toList),
-                  Some(List("test", "scala-tool", "scala-doc-tool")),
+                  Some(List("test", "scala-tool", "scala-doc-tool", "test-internal")),
                   None
                 ),
               cond = Some("github.event_name != 'pull_request'")


### PR DESCRIPTION
Turns out, transitive dependencies of `test` are counted as `test-internal`, this is now ignored.