### PR TITLE
Fix syntax highlighting for g8 snippet

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ You can find an approximate list of sbt-typelevel adopters [here](https://github
 
 We provide a [Giter8 template](http://www.foundweekends.org/giter8/index.html) for quickly starting projects with familiar workflows and best practices.
 
-```sh
+```
 sbt new typelevel/typelevel.g8
 ```
 


### PR DESCRIPTION
It's not really a shell script, so better remove the `sh`.

<img width="545" alt="Screen Shot 2023-07-12 at 11 04 07 AM" src="https://github.com/typelevel/sbt-typelevel/assets/3119428/9e7fd328-1fcf-4ed1-861a-ee496bb3f725">
