### PR TITLE
Only add scala-compat dep for supported Scalas

### DIFF
--- a/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
+++ b/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
@@ -65,7 +65,11 @@ object TypelevelSettingsPlugin extends AutoPlugin {
           )
 
       val scalacCompat =
-        Seq(CompileTime, Test).map("org.typelevel" %% "scalac-compat-annotation" % "0.1.2" % _)
+        if (Set("2.12", "2.13", "3").contains(scalaBinaryVersion.value))
+          Seq(CompileTime, Test).map(
+            "org.typelevel" %% "scalac-compat-annotation" % "0.1.2" % _)
+        else
+          Nil
 
       scalacCompat ++ plugins
     },


### PR DESCRIPTION
Some projects like cats-parse still support Scala 2.11 and I don't think it's worth supporting that in scalac-compat. Nobody should enable fatals on 2.11 ...