### PR TITLE
Allow preamble to be skipped in `Sbt` step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
       - name: sbt update
         if: matrix.java == 'temurin@8' && steps.setup-java-temurin-8.outputs.cache-hit == 'false'
         shell: bash
-        run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' reload +update
+        run: sbt +update
 
       - name: Setup Java (temurin@11)
         id: setup-java-temurin-11
@@ -116,7 +116,7 @@ jobs:
       - name: sbt update
         if: matrix.java == 'temurin@11' && steps.setup-java-temurin-11.outputs.cache-hit == 'false'
         shell: bash
-        run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' reload +update
+        run: sbt +update
 
       - name: Setup Java (temurin@17)
         id: setup-java-temurin-17
@@ -130,7 +130,7 @@ jobs:
       - name: sbt update
         if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
         shell: bash
-        run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' reload +update
+        run: sbt +update
 
       - name: Setup GraalVM (graal_22.3.2@11)
         id: setup-graalvm-22_3_2-11
@@ -144,7 +144,7 @@ jobs:
       - name: sbt update
         if: matrix.java == 'graal_22.3.2@11' && steps.setup-graalvm-22_3_2-11.outputs.cache-hit == 'false'
         shell: bash
-        run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' reload +update
+        run: sbt +update
 
       - name: Setup Java (graalvm@17)
         id: setup-java-graalvm-17
@@ -158,7 +158,7 @@ jobs:
       - name: sbt update
         if: matrix.java == 'graalvm@17' && steps.setup-java-graalvm-17.outputs.cache-hit == 'false'
         shell: bash
-        run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' reload +update
+        run: sbt +update
 
       - name: Setup Java (corretto@17)
         id: setup-java-corretto-17
@@ -172,7 +172,7 @@ jobs:
       - name: sbt update
         if: matrix.java == 'corretto@17' && steps.setup-java-corretto-17.outputs.cache-hit == 'false'
         shell: bash
-        run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' reload +update
+        run: sbt +update
 
       - name: Setup Java (semeru@17)
         id: setup-java-semeru-17
@@ -186,7 +186,7 @@ jobs:
       - name: sbt update
         if: matrix.java == 'semeru@17' && steps.setup-java-semeru-17.outputs.cache-hit == 'false'
         shell: bash
-        run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' reload +update
+        run: sbt +update
 
       - name: Check that workflows are up to date
         shell: bash
@@ -264,7 +264,7 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'temurin@8' && steps.setup-java-temurin-8.outputs.cache-hit == 'false'
-        run: sbt reload +update
+        run: sbt +update
 
       - name: Setup Java (temurin@11)
         id: setup-java-temurin-11
@@ -277,7 +277,7 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'temurin@11' && steps.setup-java-temurin-11.outputs.cache-hit == 'false'
-        run: sbt reload +update
+        run: sbt +update
 
       - name: Setup Java (temurin@17)
         id: setup-java-temurin-17
@@ -290,7 +290,7 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
-        run: sbt reload +update
+        run: sbt +update
 
       - name: Setup GraalVM (graal_22.3.2@11)
         id: setup-graalvm-22_3_2-11
@@ -303,7 +303,7 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'graal_22.3.2@11' && steps.setup-graalvm-22_3_2-11.outputs.cache-hit == 'false'
-        run: sbt reload +update
+        run: sbt +update
 
       - name: Setup Java (graalvm@17)
         id: setup-java-graalvm-17
@@ -316,7 +316,7 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'graalvm@17' && steps.setup-java-graalvm-17.outputs.cache-hit == 'false'
-        run: sbt reload +update
+        run: sbt +update
 
       - name: Setup Java (corretto@17)
         id: setup-java-corretto-17
@@ -329,7 +329,7 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'corretto@17' && steps.setup-java-corretto-17.outputs.cache-hit == 'false'
-        run: sbt reload +update
+        run: sbt +update
 
       - name: Setup Java (semeru@17)
         id: setup-java-semeru-17
@@ -342,7 +342,7 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'semeru@17' && steps.setup-java-semeru-17.outputs.cache-hit == 'false'
-        run: sbt reload +update
+        run: sbt +update
 
       - name: Download target directories (2.12, sbt-typelevelJVM)
         uses: actions/download-artifact@v3
@@ -407,7 +407,7 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'temurin@8' && steps.setup-java-temurin-8.outputs.cache-hit == 'false'
-        run: sbt reload +update
+        run: sbt +update
 
       - name: Setup Java (temurin@11)
         id: setup-java-temurin-11
@@ -420,7 +420,7 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'temurin@11' && steps.setup-java-temurin-11.outputs.cache-hit == 'false'
-        run: sbt reload +update
+        run: sbt +update
 
       - name: Setup Java (temurin@17)
         id: setup-java-temurin-17
@@ -433,7 +433,7 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
-        run: sbt reload +update
+        run: sbt +update
 
       - name: Setup GraalVM (graal_22.3.2@11)
         id: setup-graalvm-22_3_2-11
@@ -446,7 +446,7 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'graal_22.3.2@11' && steps.setup-graalvm-22_3_2-11.outputs.cache-hit == 'false'
-        run: sbt reload +update
+        run: sbt +update
 
       - name: Setup Java (graalvm@17)
         id: setup-java-graalvm-17
@@ -459,7 +459,7 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'graalvm@17' && steps.setup-java-graalvm-17.outputs.cache-hit == 'false'
-        run: sbt reload +update
+        run: sbt +update
 
       - name: Setup Java (corretto@17)
         id: setup-java-corretto-17
@@ -472,7 +472,7 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'corretto@17' && steps.setup-java-corretto-17.outputs.cache-hit == 'false'
-        run: sbt reload +update
+        run: sbt +update
 
       - name: Setup Java (semeru@17)
         id: setup-java-semeru-17
@@ -485,7 +485,7 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'semeru@17' && steps.setup-java-semeru-17.outputs.cache-hit == 'false'
-        run: sbt reload +update
+        run: sbt +update
 
       - name: Submit Dependencies
         uses: scalacenter/sbt-dependency-submission@v2
@@ -546,7 +546,7 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'temurin@8' && steps.setup-java-temurin-8.outputs.cache-hit == 'false'
-        run: sbt reload +update
+        run: sbt +update
 
       - name: Setup Java (temurin@11)
         id: setup-java-temurin-11
@@ -559,7 +559,7 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'temurin@11' && steps.setup-java-temurin-11.outputs.cache-hit == 'false'
-        run: sbt reload +update
+        run: sbt +update
 
       - name: Setup Java (temurin@17)
         id: setup-java-temurin-17
@@ -572,7 +572,7 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
-        run: sbt reload +update
+        run: sbt +update
 
       - name: Setup GraalVM (graal_22.3.2@11)
         id: setup-graalvm-22_3_2-11
@@ -585,7 +585,7 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'graal_22.3.2@11' && steps.setup-graalvm-22_3_2-11.outputs.cache-hit == 'false'
-        run: sbt reload +update
+        run: sbt +update
 
       - name: Setup Java (graalvm@17)
         id: setup-java-graalvm-17
@@ -598,7 +598,7 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'graalvm@17' && steps.setup-java-graalvm-17.outputs.cache-hit == 'false'
-        run: sbt reload +update
+        run: sbt +update
 
       - name: Setup Java (corretto@17)
         id: setup-java-corretto-17
@@ -611,7 +611,7 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'corretto@17' && steps.setup-java-corretto-17.outputs.cache-hit == 'false'
-        run: sbt reload +update
+        run: sbt +update
 
       - name: Setup Java (semeru@17)
         id: setup-java-semeru-17
@@ -624,7 +624,7 @@ jobs:
 
       - name: sbt update
         if: matrix.java == 'semeru@17' && steps.setup-java-semeru-17.outputs.cache-hit == 'false'
-        run: sbt reload +update
+        run: sbt +update
 
       - name: Generate site
         run: sbt docs/tlSite

--- a/ci/src/main/scala/org/typelevel/sbt/CrossRootProject.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/CrossRootProject.scala
@@ -194,7 +194,7 @@ object TypelevelCiJSPlugin extends AutoPlugin with RootProjectId {
     },
     githubWorkflowBuild := {
       githubWorkflowBuild.value.flatMap {
-        case testStep @ WorkflowStep.Sbt(List("test"), _, _, _, _, _, _) =>
+        case testStep @ WorkflowStep.Sbt(List("test"), _, _, _, _, _, _, _) =>
           val fastOptStep = WorkflowStep.Sbt(
             List("Test/scalaJSLinkerResult"),
             name = Some("scalaJSLink"),
@@ -226,7 +226,7 @@ object TypelevelCiNativePlugin extends AutoPlugin with RootProjectId {
     },
     githubWorkflowBuild := {
       githubWorkflowBuild.value.flatMap {
-        case testStep @ WorkflowStep.Sbt(List("test"), _, _, _, _, _, _) =>
+        case testStep @ WorkflowStep.Sbt(List("test"), _, _, _, _, _, _, _) =>
           val nativeLinkStep = WorkflowStep.Sbt(
             List("Test/nativeLink"),
             name = Some("nativeLink"),

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativePlugin.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativePlugin.scala
@@ -291,12 +291,13 @@ ${indent(rendered.mkString("\n"), 1)}"""
       case sbtStep: Sbt =>
         import sbtStep.commands
 
+        val preamble = if (sbtStep.preamble) sbtStepPreamble else Nil
         val sbtClientMode = sbt.matches("""sbt.* --client($| .*)""")
         val safeCommands =
           if (sbtClientMode)
-            s"'${(sbtStepPreamble ::: commands).mkString("; ")}'"
+            s"'${(preamble ::: commands).mkString("; ")}'"
           else
-            (sbtStepPreamble ::: commands)
+            (preamble ::: commands)
               .map { c =>
                 if (c.indexOf(' ') >= 0)
                   s"'$c'"

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/WorkflowStep.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/WorkflowStep.scala
@@ -46,9 +46,10 @@ object WorkflowStep {
       if (enableCaching)
         List(
           WorkflowStep.Sbt(
-            List("reload", "+update"),
+            List("+update"),
             name = Some(s"sbt update"),
-            cond = Some(s"$cond && steps.${setupId}.outputs.cache-hit == 'false'")
+            cond = Some(s"$cond && steps.${setupId}.outputs.cache-hit == 'false'"),
+            preamble = false
           ))
       else Nil
 
@@ -136,7 +137,8 @@ object WorkflowStep {
       cond: Option[String] = None,
       env: Map[String, String] = Map(),
       params: Map[String, String] = Map(),
-      timeoutMinutes: Option[Int] = None)
+      timeoutMinutes: Option[Int] = None,
+      preamble: Boolean = true)
       extends WorkflowStep {
     def withId(id: Option[String]) = copy(id = id)
     def withName(name: Option[String]) = copy(name = name)


### PR DESCRIPTION
... and use it to fix the `+update` step. Previously there had been some complaint that this step was wasteful. Also, it turns out that it was broken 😂 apparently `reload` is not sufficient to fully reset the sbt state, specifically changes to the `project` ...