### PR TITLE
Disable the `byname-implicit` lint on 2.13

### DIFF
--- a/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
+++ b/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
@@ -124,7 +124,8 @@ object TypelevelSettingsPlugin extends AutoPlugin {
         // - remove 'implicit-recursion' due to backward incompatibility with 2.12
         // - remove 'recurse-with-default' due to backward incompatibility with 2.12
         // - remove 'unused' because it is configured by '-Wunused'
-        "-Xlint:_,-implicit-recursion,-recurse-with-default,-unused"
+        // - remove '-byname-implicit' because scala/bug#12072
+        "-Xlint:_,-implicit-recursion,-recurse-with-default,-unused,-byname-implicit"
       )
 
       val warningsDotty = Seq.empty


### PR DESCRIPTION
Due to an interaction of a scalac bug with shapeless derivation.

- https://github.com/scala/bug/issues/12072
- https://github.com/typelevel/sbt-tpolecat/issues/33

Also it is currently blocking the fs2 migration (see https://github.com/armanbilge/fs2/pull/4).

I haven't turned my brain on enough to appreciate the intrinsic value of this lint. Are we losing much by disabling it?

Edit: I guess the PR explains it in https://github.com/scala/scala/pull/8590.

Edit 2: so the primary use of implicit conversions is for syntax. And some Cats ops do take the target as by-name. But applying syntax to a multi-line block? Too weird 😅 I don't think we're missing much.