### PR TITLE
Add `-Wconf:cat=scala3-migration:s` on 2.13

### DIFF
--- a/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
+++ b/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
@@ -120,6 +120,8 @@ object TypelevelSettingsPlugin extends AutoPlugin {
         "-Wnumeric-widen",
         "-Wunused", // all choices are enabled by default
         "-Wvalue-discard",
+        // we want to opt-in to the -Xsource:3 semantics changes, and opt-out from fatal warnings about the changes
+        "-Wconf:cat=scala3-migration:s",
         // Tune '-Xlint':
         // - remove 'implicit-recursion' due to backward incompatibility with 2.12
         // - remove 'recurse-with-default' due to backward incompatibility with 2.12


### PR DESCRIPTION
This silences warnings cause by using `-Xsource:3` flag on Scala 2.13.

It turns out that the default behavior `-Xsource:3` is a bit tricky: it changes 2.13 semantics to match Scala 3, but then it also (fatally) warns you about those semantic changes. By adding this silencing, we can opt-in to the Scala 3 semantics without being warned about it.

This should silence two annoying warnings I'm aware of:
1. The warning on `package object`s that inherit from super-classes/traits. Our attempts to workaround this have gone very wrong e.g. https://github.com/typelevel/fs2/issues/3293.

2. A new one in Scala 2.13.12 where `case class`es with `private` constructors now raise a warning "constructor modifiers are assumed by synthetic `apply` method". Which is actually exactly the behavior we want.

Thanks to Som Snytt for exposition and providing the appropriate `-Wconf` flag on the Scala Discord.