### PR TITLE
migrate to Laika 1.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "sbt-typelevel"
 
 import org.typelevel.sbt.gha.{PermissionScope, PermissionValue, Permissions}
 
-ThisBuild / tlBaseVersion := "0.5"
+ThisBuild / tlBaseVersion := "0.6"
 ThisBuild / crossScalaVersions := Seq("2.12.18")
 ThisBuild / developers ++= List(
   tlGitHubDev("armanbilge", "Arman Bilge"),

--- a/site/build.sbt
+++ b/site/build.sbt
@@ -1,2 +1,5 @@
+resolvers +=
+  "Sonatype OSS Snapshots" at "https://s01.oss.sonatype.org/content/repositories/snapshots"
+
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.3.7")
-addSbtPlugin("org.planet42" % "laika-sbt" % "0.19.5")
+addSbtPlugin("org.typelevel" % "laika-sbt" % "1.0-ab381f4-SNAPSHOT")

--- a/site/build.sbt
+++ b/site/build.sbt
@@ -1,5 +1,2 @@
-resolvers +=
-  "Sonatype OSS Snapshots" at "https://s01.oss.sonatype.org/content/repositories/snapshots"
-
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.3.7")
-addSbtPlugin("org.typelevel" % "laika-sbt" % "1.0-ab381f4-SNAPSHOT")
+addSbtPlugin("org.typelevel" % "laika-sbt" % "1.0.0-M5")

--- a/site/build.sbt
+++ b/site/build.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.3.7")
-addSbtPlugin("org.typelevel" % "laika-sbt" % "1.0.0-M5")
+addSbtPlugin("org.typelevel" % "laika-sbt" % "1.0.0")

--- a/site/src/main/scala/org/typelevel/sbt/site/GenericSiteSettings.scala
+++ b/site/src/main/scala/org/typelevel/sbt/site/GenericSiteSettings.scala
@@ -57,9 +57,12 @@ object GenericSiteSettings {
   @nowarn("cat=deprecation")
   private val legacyRelatedProjects: Initialize[Option[ThemeNavigationSection]] = setting {
     NonEmptyList.fromList(tlSiteRelatedProjects.value.toList).map { projects =>
+      val links = projects.map { case (name, url) => TextLink.external(url.toString, name) }
       ThemeNavigationSection(
         "Related Projects",
-        projects.map { case (name, url) => TextLink.external(url.toString, name) })
+        links.head,
+        links.tail*
+      )
     }
   }
 

--- a/site/src/main/scala/org/typelevel/sbt/site/TypelevelHeliumExtensions.scala
+++ b/site/src/main/scala/org/typelevel/sbt/site/TypelevelHeliumExtensions.scala
@@ -19,9 +19,9 @@ package org.typelevel.sbt.site
 import cats.effect.Async
 import cats.effect.kernel.Resource
 import laika.ast.Path
-import laika.io.model.InputTree
-import laika.format.Markdown.GitHubFlavor
 import laika.config.SyntaxHighlighting
+import laika.format.Markdown.GitHubFlavor
+import laika.io.model.InputTree
 import laika.parse.code.languages.ScalaSyntax
 import laika.theme.Theme
 import laika.theme.ThemeBuilder

--- a/site/src/main/scala/org/typelevel/sbt/site/TypelevelHeliumExtensions.scala
+++ b/site/src/main/scala/org/typelevel/sbt/site/TypelevelHeliumExtensions.scala
@@ -20,9 +20,9 @@ import cats.effect.Async
 import cats.effect.kernel.Resource
 import laika.ast.Path
 import laika.io.model.InputTree
-import laika.markdown.github.GitHubFlavor
-import laika.parse.code.SyntaxHighlighting
-import laika.parse.code.languages.DottySyntax
+import laika.format.Markdown.GitHubFlavor
+import laika.config.SyntaxHighlighting
+import laika.parse.code.languages.ScalaSyntax
 import laika.theme.Theme
 import laika.theme.ThemeBuilder
 import laika.theme.ThemeProvider
@@ -70,7 +70,7 @@ object TypelevelHeliumExtensions {
         )
         .addExtensions(
           GitHubFlavor,
-          if (scala3) SyntaxHighlighting.withSyntaxBinding("scala", DottySyntax)
+          if (scala3) SyntaxHighlighting.withSyntaxBinding("scala", ScalaSyntax.Scala3)
           else SyntaxHighlighting
         )
         .build


### PR DESCRIPTION
This is a fairly trivial upgrade (mostly tweaking imports).

I kept all deprecations in place, if there is a desire for a cleanup, I'm happy to remove them, but I think those changes would best be kept in a separate PR. This is just the most minimal step to compile `sbt-typelevel` with Laika 1.x