### PR TITLE
Introduce `tlCommandAliases` setting for defining command aliases

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -13,7 +13,7 @@ Instead of using the super-plugins, for finer-grained control you can always add
 `TypelevelKernelPlugin`
 
 - `tlIsScala3` (setting): `true`, if `scalaVersion` is 3.x.
-- `tlReplaceCommandAlias` (method): Replace a `addCommandAlias` definition.
+- `tlCommandAliases` (setting): Command aliases defined for this build.
 - `tlReleaseLocal` (command): Alias for `+publishLocal`.
 
 ### sbt-typelevel-versioning

--- a/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
+++ b/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
@@ -59,7 +59,9 @@ object TypelevelKernelPlugin extends AutoPlugin {
 
   override def globalSettings = Seq(
     Def.derive(tlIsScala3 := scalaVersion.value.startsWith("3.")),
-    tlCommandAliases := Map.empty,
+    tlCommandAliases := Map(
+      "tlReleaseLocal" -> List("reload", "project /", "+publishLocal")
+    ),
     onLoad := {
       val aliases = tlCommandAliases.value
       onLoad.value.compose { (state: State) =>
@@ -76,9 +78,6 @@ object TypelevelKernelPlugin extends AutoPlugin {
       }
     }
   )
-
-  override def buildSettings =
-    addCommandAlias("tlReleaseLocal", mkCommand(List("reload", "project /", "+publishLocal")))
 
   override def projectSettings = Seq(
     ivyConfigurations += CompileTime,

--- a/sonatype/src/main/scala/org/typelevel/sbt/TypelevelSonatypePlugin.scala
+++ b/sonatype/src/main/scala/org/typelevel/sbt/TypelevelSonatypePlugin.scala
@@ -22,7 +22,7 @@ import xerial.sbt.Sonatype
 
 import Keys._
 import Sonatype.autoImport._
-import TypelevelKernelPlugin.mkCommand
+import TypelevelKernelPlugin.autoImport._
 
 object TypelevelSonatypePlugin extends AutoPlugin {
 
@@ -37,19 +37,21 @@ object TypelevelSonatypePlugin extends AutoPlugin {
 
   import autoImport._
 
+  override def globalSettings = Seq(
+    tlCommandAliases += {
+      "tlRelease" -> List(
+        "reload",
+        "project /",
+        "+mimaReportBinaryIssues",
+        "+publish",
+        "tlSonatypeBundleReleaseIfRelevant")
+    }
+  )
+
   override def buildSettings =
     Seq(
       tlSonatypeUseLegacyHost := false,
       autoAPIMappings := true
-    ) ++ addCommandAlias(
-      "tlRelease",
-      mkCommand(
-        List(
-          "reload",
-          "project /",
-          "+mimaReportBinaryIssues",
-          "+publish",
-          "tlSonatypeBundleReleaseIfRelevant"))
     )
 
   override def projectSettings = Seq(


### PR DESCRIPTION
If I may say so myself: this is a significant improvement for usability 🎉  it makes it much much easier to define command aliases that depend on settings, and furthermore to composably modify the command aliases downstream.