### PR TITLE
Allow packaging sources from all managed directories

### DIFF
--- a/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
+++ b/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
@@ -338,19 +338,20 @@ object TypelevelSettingsPlugin extends AutoPlugin {
       }
     },
     packageSrc / mappings ++= {
-      val base = sourceManaged.value
+      val bases = managedSourceDirectories.value
       managedSources.value.map { file =>
-        file.relativeTo(base) match {
-          case Some(relative) => file -> relative.getPath
-          case None =>
+        bases
+          .map(b => file.relativeTo(b))
+          .collectFirst { case Some(relative) => file -> relative.getPath }
+          .getOrElse {
             throw new RuntimeException(
               s"""|Expected managed sources in:
-                  |$base
+                  |${bases.mkString("\n")}
                   |But found them here:
                   |$file
                   |""".stripMargin
             )
-        }
+          }
       }
     }
   )


### PR DESCRIPTION
When using generators that put sources in custom directories, eg [sbt-avro](https://github.com/sbt/sbt-avro) where the generated sources are by default is a dedicated folder in `sourceManaged / avro / $config` instead of `sourceManaged / $config`.

Using `sbt-typelevel` fails the `packageSrc` with this setup.

As the custom managed source path is added to the `managedSourceDirectories`, check the path given from the mapping is part of one of the source instead of the default `sourceManaged`.