### PR TITLE
Make `startYear` setting deterministic

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ ThisBuild / developers ++= List(
   tlGitHubDev("ChristopherDavenport", "Christopher Davenport"),
   tlGitHubDev("djspiewak", "Daniel Spiewak")
 )
-ThisBuild / startYear := Some(2022)
+ThisBuild / startYear ~= { _.map(_ => 2022) } // dog food
 
 val temurin8 = JavaSpec.temurin("8")
 val temurin17 = JavaSpec.temurin("17")

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -2,3 +2,7 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.10.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
+
+enablePlugins(BuildInfoPlugin)
+buildInfoPackage := "org.typelevel.sbt"
+buildInfoOptions ++= Seq(BuildInfoOption.PackagePrivate, BuildInfoOption.BuildTime)

--- a/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
+++ b/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
@@ -21,6 +21,10 @@ import org.typelevel.sbt.gha.GenerativePlugin
 import org.typelevel.sbt.gha.GitHubActionsPlugin
 import sbt._
 
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+
 import Keys._
 import TypelevelKernelPlugin.autoImport._
 
@@ -61,7 +65,11 @@ object TypelevelPlugin extends AutoPlugin {
         else None
       }
     },
-    startYear := Some(java.time.YearMonth.now().getYear()),
+    startYear := {
+      val instant = Instant.ofEpochMilli(BuildInfo.builtAtMillis)
+      val zdt = ZonedDateTime.ofInstant(instant, ZoneOffset.UTC)
+      Some(zdt.getYear)
+    },
     licenses += License.Apache2,
     tlCiHeaderCheck := true,
     tlCiScalafmtCheck := true,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.12.0")

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,0 +1,1 @@
+../plugins.sbt


### PR DESCRIPTION
Instead of defaulting to the current year (this was a bad default, I'm sorry) it now defaults to the current year at the time that version of sbt-typelevel was built.