### PR TITLE
Bump peaceiris/actions-gh-pages to 4.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -668,7 +668,7 @@ jobs:
 
       - name: Publish site
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-        uses: peaceiris/actions-gh-pages@v3.9.3
+        uses: peaceiris/actions-gh-pages@v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: mdocs/target/docs/site

--- a/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
+++ b/site/src/main/scala/org/typelevel/sbt/TypelevelSitePlugin.scala
@@ -167,7 +167,7 @@ object TypelevelSitePlugin extends AutoPlugin {
       def publishSiteWorkflowStep(publishPredicate: RefPredicate) =
         List(
           WorkflowStep.Use(
-            UseRef.Public("peaceiris", "actions-gh-pages", "v3.9.3"),
+            UseRef.Public("peaceiris", "actions-gh-pages", "v4.0.0"),
             Map(
               "github_token" -> s"$${{ secrets.GITHUB_TOKEN }}",
               "publish_dir" -> {


### PR DESCRIPTION
Bumps the dep so that the warning about Node v16 being deprecated (when the site gets published) will disappear.
See https://github.com/peaceiris/actions-gh-pages/blob/v4.0.0/CHANGELOG.md#400-2024-04-08