### PR TITLE
Support checking Java formatting

### DIFF
--- a/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
+++ b/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
@@ -79,12 +79,14 @@ object TypelevelPlugin extends AutoPlugin {
     GlobalScope / tlCommandAliases ++= {
       val header = tlCiHeaderCheck.value
       val scalafmt = tlCiScalafmtCheck.value
+      val javafmt = tlCiJavafmtCheck.value
       val scalafix = tlCiScalafixCheck.value
 
       val prePR = List("project /", "githubWorkflowGenerate") ++
         List("+headerCreateAll").filter(_ => header) ++
         List("+scalafixAll").filter(_ => scalafix) ++
-        List("+scalafmtAll", "scalafmtSbt").filter(_ => scalafmt)
+        List("+scalafmtAll", "scalafmtSbt").filter(_ => scalafmt) ++
+        List("javafmtAll").filter(_ => javafmt)
 
       val botHook = List("githubWorkflowGenerate") ++
         List("+headerCreateAll").filter(_ => header) ++

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -62,6 +62,7 @@ Both plugins are documented in [**sbt-typelevel-github-actions**](gha.md).
 
 - `tlCiHeaderCheck` (setting): Whether to do header check in CI (default: `false`).
 - `tlCiScalafmtCheck` (setting): Whether to do scalafmt check in CI (default: `false`).
+- `tlCiJavafmtCheck` (setting): Whether to do javafmt check in CI (default: `false`).
 - `tlCiScalafixCheck` (setting): Whether to do scalafix check in CI (default: `false`).
 - `tlCiMimaBinaryIssueCheck` (setting): Whether to do MiMa binary issues check in CI (default: `false`).
 - `tlCiDocCheck` (setting): Whether to build API docs in CI (default: `false`).


### PR DESCRIPTION
The sbt-java-formatter plugin exposes a `javafmtCheckAll` command.

https://github.com/sbt/sbt-java-formatter