### PR TITLE
Do not run the 'dependency-submission' job in CI for forked repositories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,7 +393,7 @@ jobs:
 
   dependency-submission:
     name: Submit Dependencies
-    if: github.event_name != 'pull_request'
+    if: github.event.repository.fork == false && github.event_name != 'pull_request'
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
@@ -52,6 +52,10 @@ object TypelevelCiPlugin extends AutoPlugin {
     lazy val tlCiStewardValidateConfig = settingKey[Option[File]](
       "The location of the Scala Steward config to validate (default: `.scala-steward.conf`, if exists)")
 
+    lazy val tlCiForkCondition =
+      settingKey[String](
+        "Condition for checking on CI whether this project is a fork of another (default: `github.event.repository.fork == false`)")
+
   }
 
   import autoImport._
@@ -64,6 +68,7 @@ object TypelevelCiPlugin extends AutoPlugin {
     tlCiMimaBinaryIssueCheck := false,
     tlCiDocCheck := false,
     tlCiDependencyGraphJob := true,
+    tlCiForkCondition := "github.event.repository.fork == false",
     githubWorkflowTargetBranches ++= Seq(
       "!update/**", // ignore steward branches
       "!pr/**" // escape-hatch to disable ci on a branch
@@ -139,6 +144,9 @@ object TypelevelCiPlugin extends AutoPlugin {
     },
     githubWorkflowJavaVersions := Seq(JavaSpec.temurin("8")),
     githubWorkflowAddedJobs ++= {
+      val ghEventCond = "github.event_name != 'pull_request'"
+      val jobCond = s"$tlCiForkCondition && $ghEventCond"
+
       val dependencySubmission =
         if (tlCiDependencyGraphJob.value)
           List(
@@ -155,7 +163,7 @@ object TypelevelCiPlugin extends AutoPlugin {
                   Some(List("test", "scala-tool", "scala-doc-tool", "test-internal")),
                   None
                 ),
-              cond = Some("github.event_name != 'pull_request'")
+              cond = Some(jobCond)
             ))
         else Nil
 

--- a/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
@@ -145,7 +145,7 @@ object TypelevelCiPlugin extends AutoPlugin {
     githubWorkflowJavaVersions := Seq(JavaSpec.temurin("8")),
     githubWorkflowAddedJobs ++= {
       val ghEventCond = "github.event_name != 'pull_request'"
-      val jobCond = s"$tlCiForkCondition && $ghEventCond"
+      val jobCond = s"${tlCiForkCondition.value} && $ghEventCond"
 
       val dependencySubmission =
         if (tlCiDependencyGraphJob.value)

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -67,7 +67,7 @@ Both plugins are documented in [**sbt-typelevel-github-actions**](gha.md).
 - `tlCiMimaBinaryIssueCheck` (setting): Whether to do MiMa binary issues check in CI (default: `false`).
 - `tlCiDocCheck` (setting): Whether to build API docs in CI (default: `false`).
 - `tlCiDependencyGraphJob` (setting): Whether to add a job to submit dependencies to GH (default: `true`).
-- `tlCiIsFork` (setting): Whether this project is a fork of any else (default: `false`).
+- `tlCiForkCondition` (setting): Condition for checking on CI whether this project is a fork of another (default: `github.event.repository.fork == false`).
 - `tlCiStewardValidateConfig` (setting): The location of the Scala Steward config to validate (default: `.scala-steward.conf`, if exists).
 - `tlCrossRootProject` (method): helper to create a `root` project that can aggregate both `Project`s and `CrossProject`s. Automatically creates separate jobs in the CI matrix for each platform (JVM, JS, etc.).
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -66,7 +66,8 @@ Both plugins are documented in [**sbt-typelevel-github-actions**](gha.md).
 - `tlCiScalafixCheck` (setting): Whether to do scalafix check in CI (default: `false`).
 - `tlCiMimaBinaryIssueCheck` (setting): Whether to do MiMa binary issues check in CI (default: `false`).
 - `tlCiDocCheck` (setting): Whether to build API docs in CI (default: `false`).
-- `tlCiDependencyGraphJob` (setting): Whether to add a job to submit dependencies to GH (default: `true`)
+- `tlCiDependencyGraphJob` (setting): Whether to add a job to submit dependencies to GH (default: `true`).
+- `tlCiIsFork` (setting): Whether this project is a fork of any else (default: `false`).
 - `tlCiStewardValidateConfig` (setting): The location of the Scala Steward config to validate (default: `.scala-steward.conf`, if exists).
 - `tlCrossRootProject` (method): helper to create a `root` project that can aggregate both `Project`s and `CrossProject`s. Automatically creates separate jobs in the CI matrix for each platform (JVM, JS, etc.).
 


### PR DESCRIPTION
This tries to fix the following issue in forked repositories:
```
[error] Unexpected status 404 Not Found with body:
[error] {"message":"The Dependency graph is disabled for this repository. Please enable it before submitting snapshots.","documentation_url":"https://docs.github.com/rest/dependency-graph/dependency-submission#create-a-snapshot-of-dependencies-for-a-repository","status":"404"}
```
Example: https://github.com/danicheg/cats/actions/runs/10027887278/job/27714122616#step:10:554