### PR TITLE
Fallback on non-MavenRepository repos

### DIFF
--- a/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
@@ -187,7 +187,7 @@ object TypelevelCiPlugin extends AutoPlugin {
   override def projectSettings: Seq[Setting[_]] = Seq(
     Test / Keys.executeTests := {
       val results: Tests.Output = (Test / Keys.executeTests).value
-      GitHubActionsPlugin.appendtoStepSummary(
+      GitHubActionsPlugin.appendToStepSummary(
         renderTestResults(Keys.thisProject.value.id, Keys.scalaVersion.value, results)
       )
       results

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/GitHubActionsPlugin.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/GitHubActionsPlugin.scala
@@ -120,7 +120,7 @@ object GitHubActionsPlugin extends AutoPlugin {
     }
   }
 
-  private[typelevel] def appendtoStepSummary(summaryText: String) =
+  private[typelevel] def appendToStepSummary(summaryText: String) =
     Option(System.getenv("GITHUB_STEP_SUMMARY")).map { summaryFile =>
       IO.write(new File(summaryFile), summaryText, append = true)
     }

--- a/sonatype-ci-release/src/main/scala/org/typelevel/sbt/TypelevelSonatypeCiReleasePlugin.scala
+++ b/sonatype-ci-release/src/main/scala/org/typelevel/sbt/TypelevelSonatypeCiReleasePlugin.scala
@@ -78,9 +78,11 @@ object TypelevelSonatypeCiReleasePlugin extends AutoPlugin {
                 |resolvers += "${repo.name}" at "${repo.root}"
                 |```
                 |""".stripMargin
+
+          case _ => ""
         }
 
-        GitHubActionsPlugin.appendtoStepSummary(
+        GitHubActionsPlugin.appendToStepSummary(
           s"""|## Published `$v`
               |${resolver}""".stripMargin
         )

--- a/sonatype-ci-release/src/main/scala/org/typelevel/sbt/TypelevelSonatypeCiReleasePlugin.scala
+++ b/sonatype-ci-release/src/main/scala/org/typelevel/sbt/TypelevelSonatypeCiReleasePlugin.scala
@@ -81,7 +81,7 @@ object TypelevelSonatypeCiReleasePlugin extends AutoPlugin {
 
           case repo: URLRepository =>
             s"""|```scala
-                |resolvers += Resolver.url("${repo.name}", ${repo.patterns}, ${repo.allowInsecureProtocol})
+                |resolvers += URLRepository("${repo.name}", ${repo.patterns}, ${repo.allowInsecureProtocol})
                 |```
                 |""".stripMargin
           // fallback to print at least _something_

--- a/sonatype-ci-release/src/main/scala/org/typelevel/sbt/TypelevelSonatypeCiReleasePlugin.scala
+++ b/sonatype-ci-release/src/main/scala/org/typelevel/sbt/TypelevelSonatypeCiReleasePlugin.scala
@@ -79,7 +79,13 @@ object TypelevelSonatypeCiReleasePlugin extends AutoPlugin {
                 |```
                 |""".stripMargin
 
-          case _ => ""
+          case repo: URLRepository =>
+            s"""|```scala
+                |resolvers += Resolver.url("${repo.name}", ${repo.patterns}, ${repo.allowInsecureProtocol})
+                |```
+                |""".stripMargin
+          // fallback to print at least _something_
+          case other => other.toString
         }
 
         GitHubActionsPlugin.appendToStepSummary(


### PR DESCRIPTION
Currently, if you publish to the new Sonatype Central repository (#721), during publishing you'll encounter the following issue:

```
[error] scala.MatchError: URLRepository(https://settingkey/(This / This / This / sonatypeCredentialHost), Patterns(ivyPatterns=Vector(), artifactPatterns=Vector(), isMavenCompatible=false, descriptorOptional=false, skipConsistencyCheck=false), false) (of class sbt.librarymanagement.URLRepository)
```

It happens in the code that computes a step summary. Originally, I tried to write a rendering function for the entire `URLRepository`, but serializing `Patterns` is a bit tedious and the step summary isn't all that useful, so I figured we can start with an empty string for now.