### PR TITLE
Improved prePR

### DIFF
--- a/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
+++ b/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
@@ -76,24 +76,30 @@ object TypelevelPlugin extends AutoPlugin {
         java <- githubWorkflowJavaVersions.value.tail // default java is head
       } yield MatrixExclude(Map("scala" -> scala, "java" -> java.render))
     },
-    GlobalScope / tlCommandAliases ++= {
+    GlobalScope / tlPrePRSteps ++= {
       val header = tlCiHeaderCheck.value
       val scalafmt = tlCiScalafmtCheck.value
       val javafmt = tlCiJavafmtCheck.value
       val scalafix = tlCiScalafixCheck.value
 
-      val prePR = List("project /", "githubWorkflowGenerate") ++
+      List("project /", "githubWorkflowGenerate") ++
         List("+headerCreateAll").filter(_ => header) ++
         List("+scalafixAll").filter(_ => scalafix) ++
         List("+scalafmtAll", "scalafmtSbt").filter(_ => scalafmt) ++
-        List("javafmtAll").filter(_ => javafmt)
+        List("javafmtAll").filter(_ => javafmt) ++
+        List("compile", "test")
+    },
+    GlobalScope / tlCommandAliases ++= {
+      val header = tlCiHeaderCheck.value
+      val scalafmt = tlCiScalafmtCheck.value
+      val javafmt = tlCiJavafmtCheck.value
 
       val botHook = List("githubWorkflowGenerate") ++
         List("+headerCreateAll").filter(_ => header) ++
+        List("javafmtAll").filter(_ => javafmt) ++
         List("+scalafmtAll", "scalafmtSbt").filter(_ => scalafmt)
 
       Map(
-        "prePR" -> prePR,
         "tlPrePrBotHook" -> botHook
       )
     }

--- a/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
+++ b/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
@@ -45,6 +45,9 @@ object TypelevelKernelPlugin extends AutoPlugin {
       "Command aliases defined for this build"
     )
 
+    lazy val tlPrePRSteps =
+      settingKey[List[String]]("Steps to be performed before a user submits a PR")
+
     @deprecated(
       "Use `tlCommandAliases` for a more composable command definition experience",
       "0.6.1")
@@ -62,7 +65,8 @@ object TypelevelKernelPlugin extends AutoPlugin {
   override def globalSettings = Seq(
     Def.derive(tlIsScala3 := scalaVersion.value.startsWith("3.")),
     tlCommandAliases := Map(
-      "tlReleaseLocal" -> List("reload", "project /", "+publishLocal")
+      "tlReleaseLocal" -> List("reload", "project /", "+publishLocal"),
+      "prePR" -> ("reload" :: "project /" :: tlPrePRSteps.value)
     ),
     onLoad := {
       val aliases = tlCommandAliases.value
@@ -78,7 +82,8 @@ object TypelevelKernelPlugin extends AutoPlugin {
       onUnload.value.compose { (state: State) =>
         aliases.foldLeft(state) { (state, alias) => BasicCommands.removeAlias(state, alias) }
       }
-    }
+    },
+    tlPrePRSteps := List.empty
   )
 
   @nowarn("cat=deprecation")


### PR DESCRIPTION
I've found `prePR` to be a nice handy alias, but a little clumsy to extend.  My team has been doing something similar for a while, but did a command alias in every project.  I thought it would be nice if we had a handy easy way to extend the list of checks a developer should perform before submitting a pr so they have fewer painful moments realizing they forget a step and now their PR has failed.