### PR TITLE
Update sbt-scalafix to 0.13.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "sbt-typelevel"
 
 import org.typelevel.sbt.gha.{PermissionScope, PermissionValue, Permissions}
 
-ThisBuild / tlBaseVersion := "0.7"
+ThisBuild / tlBaseVersion := "0.8"
 ThisBuild / crossScalaVersions := Seq("2.12.20")
 ThisBuild / developers ++= List(
   tlGitHubDev("armanbilge", "Arman Bilge"),

--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.12.1")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.13.0")


### PR DESCRIPTION
0.13.0 allows using `OrganizeImports.removeUnused` in Scala 3.3.4, which is very helpful