### PR TITLE
Use `actions/setup-java` to install GraalVM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Setup Java (graalvm@17)
         id: setup-java-graalvm-17
         if: matrix.java == 'graalvm@17'
-        uses: graalvm/setup-graalvm@v1
+        uses: actions/setup-java@v4
         with:
           distribution: graalvm
           java-version: 17
@@ -318,7 +318,7 @@ jobs:
       - name: Setup Java (graalvm@17)
         id: setup-java-graalvm-17
         if: matrix.java == 'graalvm@17'
-        uses: graalvm/setup-graalvm@v1
+        uses: actions/setup-java@v4
         with:
           distribution: graalvm
           java-version: 17
@@ -464,7 +464,7 @@ jobs:
       - name: Setup Java (graalvm@17)
         id: setup-java-graalvm-17
         if: matrix.java == 'graalvm@17'
-        uses: graalvm/setup-graalvm@v1
+        uses: actions/setup-java@v4
         with:
           distribution: graalvm
           java-version: 17
@@ -606,7 +606,7 @@ jobs:
       - name: Setup Java (graalvm@17)
         id: setup-java-graalvm-17
         if: matrix.java == 'graalvm@17'
-        uses: graalvm/setup-graalvm@v1
+        uses: actions/setup-java@v4
         with:
           distribution: graalvm
           java-version: 17

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/JavaSpec.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/JavaSpec.scala
@@ -33,6 +33,8 @@ object JavaSpec {
   def oracle(version: String): JavaSpec = JavaSpec(Distribution.Oracle, version)
   def semeru(version: String): JavaSpec = JavaSpec(Distribution.Semeru, version)
   def microsoft(version: String): JavaSpec = JavaSpec(Distribution.Microsoft, version)
+  def dragonwell(version: String): JavaSpec = JavaSpec(Distribution.Dragonwell, version)
+  def sapmachine(version: String): JavaSpec = JavaSpec(Distribution.SapMachine, version)
 
   sealed abstract class Distribution(val rendering: String) extends Product with Serializable
 
@@ -48,5 +50,7 @@ object JavaSpec {
     case object GraalVM extends Distribution("graalvm")
     case object Semeru extends Distribution("semeru")
     case object Microsoft extends Distribution("microsoft")
+    case object Dragonwell extends Distribution("dragonwell")
+    case object SapMachine extends Distribution("sapmachine")
   }
 }

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/WorkflowStep.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/WorkflowStep.scala
@@ -56,8 +56,6 @@ object WorkflowStep {
           ))
       else Nil
 
-    val SetupJavaAction = UseRef.Public("actions", "setup-java", "v4")
-    val SetupGraalVMAction = UseRef.Public("graalvm", "setup-graalvm", "v1")
     val sbtCacheParams = if (enableCaching) Map("cache" -> "sbt") else Map.empty
 
     versions flatMap {
@@ -65,7 +63,7 @@ object WorkflowStep {
         val setupId = s"setup-graalvm-${graalVersion}-$javaVersion".replace('.', '_')
         val cond = s"matrix.java == '${jv.render}'"
         WorkflowStep.Use(
-          SetupGraalVMAction,
+          UseRef.Public("graalvm", "setup-graalvm", "v1"),
           name = Some(s"Setup GraalVM (${jv.render})"),
           id = Some(setupId),
           cond = Some(cond),
@@ -78,7 +76,7 @@ object WorkflowStep {
         val cond = s"matrix.java == '${jv.render}'"
 
         WorkflowStep.Use(
-          if (dist == JavaSpec.Distribution.GraalVM) SetupGraalVMAction else SetupJavaAction,
+          UseRef.Public("actions", "setup-java", "v4"),
           name = Some(s"Setup Java (${jv.render})"),
           id = Some(setupId),
           cond = Some(cond),


### PR DESCRIPTION
Since v4.4.0 graalvm can be installed using setup-java https://github.com/actions/setup-java/releases/tag/v4.4.0 (for legacy versions setup-graalvm is still needed)

Not sure if we need to expose these additional distributions: 
- https://github.com/actions/setup-java/releases/tag/v4.3.0 supports SapMachine 
- https://github.com/actions/setup-java/releases/tag/v3.13.0 supports Dragonwell