### PR TITLE
Revert "Update sbt-sonatype to 3.12.0"

### DIFF
--- a/sonatype/build.sbt
+++ b/sonatype/build.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.4")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.12.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.11.3")
 addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")


### PR DESCRIPTION
... to restore Java 8 support.

- https://github.com/xerial/sbt-sonatype/issues/530

Reverts https://github.com/typelevel/sbt-typelevel/pull/754.