### PR TITLE
pin to ubuntu-22.04 as default runner OS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     name: Build and Test
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-latest, windows-latest]
         scala: [2.12]
         java:
           - temurin@8
@@ -196,12 +196,12 @@ jobs:
         run: sbt githubWorkflowCheck
 
       - name: Check headers and formatting
-        if: matrix.java == 'temurin@8' && matrix.os == 'ubuntu-latest'
+        if: matrix.java == 'temurin@8' && matrix.os == 'ubuntu-22.04'
         shell: bash
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' headerCheckAll scalafmtCheckAll 'project /' scalafmtSbtCheck
 
       - name: Check scalafix lints
-        if: matrix.java == 'temurin@8' && matrix.os == 'ubuntu-latest'
+        if: matrix.java == 'temurin@8' && matrix.os == 'ubuntu-22.04'
         shell: bash
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' 'scalafixAll --check'
 
@@ -210,12 +210,12 @@ jobs:
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' test
 
       - name: Check binary compatibility
-        if: matrix.java == 'temurin@8' && matrix.os == 'ubuntu-latest'
+        if: matrix.java == 'temurin@8' && matrix.os == 'ubuntu-22.04'
         shell: bash
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' mimaReportBinaryIssues
 
       - name: Generate API documentation
-        if: matrix.java == 'temurin@8' && matrix.os == 'ubuntu-latest'
+        if: matrix.java == 'temurin@8' && matrix.os == 'ubuntu-22.04'
         shell: bash
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' doc
 
@@ -246,7 +246,7 @@ jobs:
     if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         java: [temurin@8]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
@@ -393,7 +393,7 @@ jobs:
     if: github.event.repository.fork == false && github.event_name != 'pull_request'
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -510,7 +510,7 @@ jobs:
     name: Validate Steward Config
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         java: [temurin@11]
     runs-on: ${{ matrix.os }}
     steps:
@@ -535,7 +535,7 @@ jobs:
     name: Generate Site
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         java: [temurin@11]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,17 +12,17 @@ pull_request_rules:
   - or:
     - body~=labels:.*early-semver-patch
     - body~=labels:.*early-semver-minor
-  - status-success=Build and Test (ubuntu-latest, 2.12, temurin@8, sbt-typelevelJVM)
-  - status-success=Build and Test (ubuntu-latest, 2.12, temurin@11, sbt-typelevelJVM)
-  - status-success=Build and Test (ubuntu-latest, 2.12, temurin@17, sbt-typelevelJVM)
-  - status-success=Build and Test (ubuntu-latest, 2.12, graal_22.3.2@11, sbt-typelevelJVM)
-  - status-success=Build and Test (ubuntu-latest, 2.12, graalvm@17, sbt-typelevelJVM)
-  - status-success=Build and Test (ubuntu-latest, 2.12, corretto@17, sbt-typelevelJVM)
-  - status-success=Build and Test (ubuntu-latest, 2.12, semeru@17, sbt-typelevelJVM)
+  - status-success=Build and Test (ubuntu-22.04, 2.12, temurin@8, sbt-typelevelJVM)
+  - status-success=Build and Test (ubuntu-22.04, 2.12, temurin@11, sbt-typelevelJVM)
+  - status-success=Build and Test (ubuntu-22.04, 2.12, temurin@17, sbt-typelevelJVM)
+  - status-success=Build and Test (ubuntu-22.04, 2.12, graal_22.3.2@11, sbt-typelevelJVM)
+  - status-success=Build and Test (ubuntu-22.04, 2.12, graalvm@17, sbt-typelevelJVM)
+  - status-success=Build and Test (ubuntu-22.04, 2.12, corretto@17, sbt-typelevelJVM)
+  - status-success=Build and Test (ubuntu-22.04, 2.12, semeru@17, sbt-typelevelJVM)
   - status-success=Build and Test (macos-latest, 2.12, temurin@17, sbt-typelevelJVM)
   - status-success=Build and Test (windows-latest, 2.12, temurin@8, sbt-typelevelJVM)
-  - status-success=Validate Steward Config (ubuntu-latest, temurin@11)
-  - status-success=Generate Site (ubuntu-latest, temurin@11)
+  - status-success=Validate Steward Config (ubuntu-22.04, temurin@11)
+  - status-success=Generate Site (ubuntu-22.04, temurin@11)
   - '#approved-reviews-by>=1'
   actions:
     merge: {}

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativeKeys.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativeKeys.scala
@@ -87,7 +87,7 @@ trait GenerativeKeys {
   lazy val githubWorkflowScalaVersions = settingKey[Seq[String]](
     "A list of Scala versions on which to build the project (default: crossScalaVersions.value)")
   lazy val githubWorkflowOSes =
-    settingKey[Seq[String]]("A list of OS names (default: [ubuntu-latest])")
+    settingKey[Seq[String]]("A list of OS names (default: [ubuntu-22.04])")
 
   lazy val githubWorkflowDependencyPatterns = settingKey[Seq[String]](
     "A list of file globes within the project which affect dependency information (default: [**/*.sbt, project/build.properties])")

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativePlugin.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativePlugin.scala
@@ -651,7 +651,7 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}
       else
         scalas
     },
-    githubWorkflowOSes := Seq("ubuntu-latest"),
+    githubWorkflowOSes := Seq("ubuntu-22.04"),
     githubWorkflowDependencyPatterns := Seq("**/*.sbt", "project/build.properties"),
     githubWorkflowTargetBranches := Seq("**"),
     githubWorkflowTargetTags := Seq(),

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/WorkflowJob.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/WorkflowJob.scala
@@ -74,7 +74,7 @@ object WorkflowJob {
       cond: Option[String] = None,
       permissions: Option[Permissions] = None,
       env: Map[String, String] = Map(),
-      oses: List[String] = List("ubuntu-latest"),
+      oses: List[String] = List("ubuntu-22.04"),
       scalas: List[String] = List("2.13"),
       javas: List[JavaSpec] = List(JavaSpec.temurin("11")),
       needs: List[String] = List(),


### PR DESCRIPTION
This week we saw a lot of chaos because the `ubuntu-latest` runner tag was switched to the `ubuntu-24.04` image, away from the `ubuntu-22.04` image[^1]. 

I'm proposing that we pin the ubuntu runner OS to 22.04 as the default value so we can avoid that chaos in the future. By pinning we can
- test here before updating to a new runner tag, preventing CI for sbt-typelevel users from breaking unexpectedly (breaking due to this kind of change at least lol)
- communicate with users via a major release + release notes if a major change like this happens again

[^1]: And that switch is now being [rolled back](https://github.com/actions/runner-images/issues/10636#issuecomment-2417293457) for the time being 😵 