### PR TITLE
Tweak the publication condition to prevent publishing from forked repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,17 +224,17 @@ jobs:
         run: pwd
 
       - name: Make target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
+        if: github.event.repository.fork == false && github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
         shell: bash
         run: mkdir -p github/target github-actions/target kernel/target versioning/target ci-release/target scalafix/target site/target ci-signing/target mergify/target unidoc/target mima/target no-publish/target sonatype/target ci/target sonatype-ci-release/target core/target settings/target project/target
 
       - name: Compress target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
+        if: github.event.repository.fork == false && github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
         shell: bash
         run: tar cf targets.tar github/target github-actions/target kernel/target versioning/target ci-release/target scalafix/target site/target ci-signing/target mergify/target unidoc/target mima/target no-publish/target sonatype/target ci/target sonatype-ci-release/target core/target settings/target project/target
 
       - name: Upload target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
+        if: github.event.repository.fork == false && github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
         uses: actions/upload-artifact@v4
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.scala }}-${{ matrix.project }}
@@ -243,7 +243,7 @@ jobs:
   publish:
     name: Publish Artifacts
     needs: [build, validate-steward]
-    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
+    if: github.event.repository.fork == false && github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
     strategy:
       matrix:
         os: [ubuntu-22.04]

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ tags
 .bloop/
 metals.sbt
 .vscode
+
+# Macos
+.DS_Store
+.Trashes

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,3 @@ tags
 .bloop/
 metals.sbt
 .vscode
-
-# Macos
-.DS_Store
-.Trashes

--- a/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
@@ -23,6 +23,7 @@ import org.typelevel.sbt.gha.GitHubActionsPlugin
 import org.typelevel.sbt.gha.WorkflowStep
 import sbt._
 
+import scala.annotation.nowarn
 import scala.language.experimental.macros
 
 object TypelevelCiPlugin extends AutoPlugin {
@@ -52,6 +53,7 @@ object TypelevelCiPlugin extends AutoPlugin {
     lazy val tlCiStewardValidateConfig = settingKey[Option[File]](
       "The location of the Scala Steward config to validate (default: `.scala-steward.conf`, if exists)")
 
+    @deprecated("Use `githubWorkflowForkCondition` instead", "0.7.8")
     lazy val tlCiForkCondition =
       settingKey[String](
         "Condition for checking on CI whether this project is a fork of another (default: `github.event.repository.fork == false`)")
@@ -60,6 +62,7 @@ object TypelevelCiPlugin extends AutoPlugin {
 
   import autoImport._
 
+  @nowarn("cat=deprecation")
   override def buildSettings = Seq(
     tlCiHeaderCheck := false,
     tlCiScalafmtCheck := false,
@@ -68,7 +71,7 @@ object TypelevelCiPlugin extends AutoPlugin {
     tlCiMimaBinaryIssueCheck := false,
     tlCiDocCheck := false,
     tlCiDependencyGraphJob := true,
-    tlCiForkCondition := "github.event.repository.fork == false",
+    tlCiForkCondition := githubWorkflowForkCondition.value,
     githubWorkflowTargetBranches ++= Seq(
       "!update/**", // ignore steward branches
       "!pr/**" // escape-hatch to disable ci on a branch
@@ -145,7 +148,7 @@ object TypelevelCiPlugin extends AutoPlugin {
     githubWorkflowJavaVersions := Seq(JavaSpec.temurin("8")),
     githubWorkflowAddedJobs ++= {
       val ghEventCond = "github.event_name != 'pull_request'"
-      val jobCond = s"${tlCiForkCondition.value} && $ghEventCond"
+      val jobCond = s"${githubWorkflowForkCondition.value} && $ghEventCond"
 
       val dependencySubmission =
         if (tlCiDependencyGraphJob.value)

--- a/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
@@ -148,7 +148,7 @@ object TypelevelCiPlugin extends AutoPlugin {
     githubWorkflowJavaVersions := Seq(JavaSpec.temurin("8")),
     githubWorkflowAddedJobs ++= {
       val ghEventCond = "github.event_name != 'pull_request'"
-      val jobCond = s"${githubWorkflowForkCondition.value} && $ghEventCond"
+      val jobCond = s"${tlCiForkCondition.value} && $ghEventCond"
 
       val dependencySubmission =
         if (tlCiDependencyGraphJob.value)

--- a/docs/gha.md
+++ b/docs/gha.md
@@ -80,7 +80,7 @@ Any and all settings which affect the behavior of the generative plugin should b
 - `githubWorkflowEnv` : `Map[String, String]` – An environment which is global to the entire **ci.yml** workflow. Defaults to `Map("GITHUB_TOKEN" -> "${{ secrets.GITHUB_TOKEN }}")` since it's so commonly needed.
 - `githubWorkflowAddedJobs` : `Seq[WorkflowJob]` – A convenience mechanism for adding extra custom jobs to the **ci.yml** workflow (though you can also do this by modifying `githubWorkflowGeneratedCI`). Defaults to empty.
 - `githubWorkflowConcurrency` : `Option[Concurrency]` - Use concurrency to ensure that only a single workflow within the same concurrency group will run at a time. Defaults to `${{ github.workflow }} @ ${{ github.ref }}`.
-- `githubWorkflowForkCondition` : `String` — A condition in the workflow to determine if this project is a fork of another (default: `github.event.repository.fork == false`)
+- `githubWorkflowForkCondition` : `String` — A condition to determine if this workflow is running on a fork (default: `github.event.repository.fork == false`).
 
 #### `build` Job
 

--- a/docs/gha.md
+++ b/docs/gha.md
@@ -80,6 +80,7 @@ Any and all settings which affect the behavior of the generative plugin should b
 - `githubWorkflowEnv` : `Map[String, String]` – An environment which is global to the entire **ci.yml** workflow. Defaults to `Map("GITHUB_TOKEN" -> "${{ secrets.GITHUB_TOKEN }}")` since it's so commonly needed.
 - `githubWorkflowAddedJobs` : `Seq[WorkflowJob]` – A convenience mechanism for adding extra custom jobs to the **ci.yml** workflow (though you can also do this by modifying `githubWorkflowGeneratedCI`). Defaults to empty.
 - `githubWorkflowConcurrency` : `Option[Concurrency]` - Use concurrency to ensure that only a single workflow within the same concurrency group will run at a time. Defaults to `${{ github.workflow }} @ ${{ github.ref }}`.
+- `githubWorkflowForkCondition` : `String` — A condition in the workflow to determine if this project is a fork of another (default: `github.event.repository.fork == false`)
 
 #### `build` Job
 

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativeKeys.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativeKeys.scala
@@ -113,6 +113,9 @@ trait GenerativeKeys {
     s"Permissions to use for the global workflow (default: None)")
   lazy val githubWorkflowAddedJobs = settingKey[Seq[WorkflowJob]](
     "A list of additional jobs to add to the CI workflow (default: [])")
+  lazy val githubWorkflowForkCondition =
+    settingKey[String](
+      "A condition in the workflow to determine if this project is a fork of another (default: `github.event.repository.fork == false`)")
 }
 
 object GenerativeKeys extends GenerativeKeys

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativeKeys.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativeKeys.scala
@@ -115,7 +115,7 @@ trait GenerativeKeys {
     "A list of additional jobs to add to the CI workflow (default: [])")
   lazy val githubWorkflowForkCondition =
     settingKey[String](
-      "A condition in the workflow to determine if this project is a fork of another (default: `github.event.repository.fork == false`)")
+      "A condition to determine if this workflow is running on a fork (default: `github.event.repository.fork == false`)")
 }
 
 object GenerativeKeys extends GenerativeKeys

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativePlugin.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativePlugin.scala
@@ -852,6 +852,9 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}
   )
 
   private val publicationCond = Def setting {
+    val notPRCond = "github.event_name != 'pull_request'"
+    val notForkCond = "github.event.repository.fork == false"
+
     val publicationCondPre =
       githubWorkflowPublishTargetBranches
         .value
@@ -862,7 +865,8 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}
       case Some(cond) => publicationCondPre + " && (" + cond + ")"
       case None => publicationCondPre
     }
-    s"github.event_name != 'pull_request' && $publicationCond"
+
+    s"$notForkCond && $notPRCond && $publicationCond"
   }
 
   private val sbt = Def.setting {

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativePlugin.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativePlugin.scala
@@ -854,7 +854,7 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}
 
   private val publicationCond = Def setting {
     val notPRCond = "github.event_name != 'pull_request'"
-    val notForkCond = "github.event.repository.fork == false"
+    val forkCond = githubWorkflowForkCondition.value
 
     val publicationCondPre =
       githubWorkflowPublishTargetBranches
@@ -867,7 +867,7 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}
       case None => publicationCondPre
     }
 
-    s"$notForkCond && $notPRCond && $publicationCond"
+    s"$forkCond && $notPRCond && $publicationCond"
   }
 
   private val sbt = Def.setting {

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativePlugin.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativePlugin.scala
@@ -658,7 +658,8 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}
     githubWorkflowTargetPaths := Paths.None,
     githubWorkflowEnv := Map("GITHUB_TOKEN" -> s"$${{ secrets.GITHUB_TOKEN }}"),
     githubWorkflowPermissions := None,
-    githubWorkflowAddedJobs := Seq()
+    githubWorkflowAddedJobs := Seq(),
+    githubWorkflowForkCondition := "github.event.repository.fork == false"
   )
 
   private lazy val internalTargetAggregation =


### PR DESCRIPTION
One might argue that users can use `githubWorkflowPublishCond` to prevent publishing from forked repos. Sure, but I’m confident this condition should be the default. Adding it manually to the build of dozens of projects isn’t exactly ideal, either.
This is basically the same as what we did in #720, but adding the same SBT setting again just feels a bit extra to me 🤷🏻