### PR TITLE
Change sort order of versions so final releases are last not first.

### DIFF
--- a/kernel/src/main/scala/org/typelevel/sbt/kernel/V.scala
+++ b/kernel/src/main/scala/org/typelevel/sbt/kernel/V.scala
@@ -51,8 +51,8 @@ private[sbt] final case class V(
         if (z != 0) return z
         (this.prerelease, that.prerelease) match {
           case (None, None) => 0
-          case (Some(_), None) => 1
-          case (None, Some(_)) => -1
+          case (Some(_), None) => -1
+          case (None, Some(_)) => 1
           case (Some(thisPrerelease), Some(thatPrerelease)) =>
             // TODO not great, but not everyone uses Ms and RCs
             thisPrerelease.compare(thatPrerelease)

--- a/kernel/src/test/scala/org/typelevel/sbt/kernel/VSuite.scala
+++ b/kernel/src/test/scala/org/typelevel/sbt/kernel/VSuite.scala
@@ -17,6 +17,7 @@
 package org.typelevel.sbt.kernel
 
 import munit.FunSuite
+import scala.util.Random
 
 class VSuite extends FunSuite {
 
@@ -169,21 +170,24 @@ class VSuite extends FunSuite {
     assertEquals(patch1 < p1patch1, true)
   }
 
-  test("x.y.1-M1 < x.y.1") {
+  test("x.y.1-M1 < x.y.1-RC1 < x.y.1") {
     val pre0 = V(0, 5, Some(1), Some("M1"))
-    val nopre0 = V(0, 5, Some(2), None)
+    val nopre0 = V(0, 5, Some(1), None)
     assertEquals(pre0 < nopre0, true)
     val pre1 = V(1, 5, Some(1), Some("M1"))
-    val nopre1 = V(1, 5, Some(2), None)
+    val nopre1 = V(1, 5, Some(1), None)
     assertEquals(pre1 < nopre1, true)
-  }
 
-  test("pre-release is before release") {
     val release = V(0, 1, Some(1), None)
     val rc1 = V(0, 1, Some(1), Some("RC1"))
     val rc2 = V(0, 1, Some(1), Some("RC2"))
-    val expected = List(rc1, rc2, release)
-    assertEquals(List(rc2, release, rc1).sorted, expected)
-    assertEquals(List(release, rc1, rc2).sorted, expected)
+    val m1 = V(0, 1, Some(1), Some("M1"))
+    val m2 = V(0, 1, Some(1), Some("M2"))
+    val expected = List(m1, m2, rc1, rc2, release)
+    assertEquals(List(rc2, m1, release, m2, rc1).sorted, expected)
+    assertEquals(List(release, rc1, rc2, m2, m1).sorted, expected)
+
+    val random = Random.shuffle(List(release, rc1, rc2, m2, m1))
+    assertEquals(clue(random).sorted, expected)
   }
 }

--- a/kernel/src/test/scala/org/typelevel/sbt/kernel/VSuite.scala
+++ b/kernel/src/test/scala/org/typelevel/sbt/kernel/VSuite.scala
@@ -183,7 +183,7 @@ class VSuite extends FunSuite {
     val rc1 = V(0, 1, Some(1), Some("RC1"))
     val rc2 = V(0, 1, Some(1), Some("RC2"))
     val expected = List(rc1, rc2, release)
-    assertEquals(List(rc2, release, rc1), expected)
-    assertEquals(List(release, rc1, rc2), expected)
+    assertEquals(List(rc2, release, rc1).sorted, expected)
+    assertEquals(List(release, rc1, rc2).sorted, expected)
   }
 }

--- a/kernel/src/test/scala/org/typelevel/sbt/kernel/VSuite.scala
+++ b/kernel/src/test/scala/org/typelevel/sbt/kernel/VSuite.scala
@@ -178,4 +178,12 @@ class VSuite extends FunSuite {
     assertEquals(pre1 < nopre1, true)
   }
 
+  test("pre-release is before release") {
+    val release = V(0, 1, Some(1), None)
+    val rc1 = V(0, 1, Some(1), Some("RC1"))
+    val rc2 = V(0, 1, Some(1), Some("RC2"))
+    val expected = List(rc1, rc2, release)
+    assertEquals(List(rc2, release, rc1), expected)
+    assertEquals(List(release, rc1, rc2), expected)
+  }
 }

--- a/kernel/src/test/scala/org/typelevel/sbt/kernel/VSuite.scala
+++ b/kernel/src/test/scala/org/typelevel/sbt/kernel/VSuite.scala
@@ -17,6 +17,7 @@
 package org.typelevel.sbt.kernel
 
 import munit.FunSuite
+
 import scala.util.Random
 
 class VSuite extends FunSuite {


### PR DESCRIPTION
There was a minor issue where if a commit was tagged with both an RC and a final release, "v0.6.0-RC1" and "v0.6.0", the current version would be the most recent RC and not the final version.  This PR switches the bias on sort, so prereleases come before final releases.