### PR TITLE
Replace sbt-sonatype with sbt-1.11.0 for Central Portal

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "sbt-typelevel"
 
 import org.typelevel.sbt.gha.{PermissionScope, PermissionValue, Permissions}
 
-ThisBuild / tlBaseVersion := "0.7"
+ThisBuild / tlBaseVersion := "0.8"
 ThisBuild / crossScalaVersions := Seq("2.12.20")
 ThisBuild / developers ++= List(
   tlGitHubDev("armanbilge", "Arman Bilge"),

--- a/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
+++ b/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
@@ -20,7 +20,6 @@ import de.heikoseeberger.sbtheader.HeaderPlugin
 import org.typelevel.sbt.gha.GenerativePlugin
 import org.typelevel.sbt.gha.GitHubActionsPlugin
 import sbt._
-import xerial.sbt.Sonatype
 
 import Keys._
 import TypelevelKernelPlugin.autoImport._
@@ -52,7 +51,6 @@ object TypelevelPlugin extends AutoPlugin {
   import TypelevelVersioningPlugin.autoImport._
   import GenerativePlugin.autoImport._
   import GitHubActionsPlugin.autoImport._
-  import Sonatype.autoImport._
 
   override def buildSettings = Seq(
     organization := "org.typelevel",
@@ -67,14 +65,7 @@ object TypelevelPlugin extends AutoPlugin {
     licenses += License.Apache2,
     tlCiHeaderCheck := true,
     tlCiScalafmtCheck := true,
-    tlCiReleaseBranches := {
-      val central =
-        sonatypeCredentialHost.value.equalsIgnoreCase(Sonatype.sonatypeCentralHost)
-      if (central && tlUntaggedAreSnapshots.value)
-        Seq() // Sonatype Central does not support snapshots
-      else
-        Seq("main")
-    },
+    tlCiReleaseBranches := Seq("main"),
     Def.derive(tlFatalWarnings := githubIsWorkflowBuild.value),
     githubWorkflowJavaVersions := {
       Seq(JavaSpec.temurin(tlJdkRelease.value.getOrElse(8).toString))

--- a/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
+++ b/core/src/main/scala/org/typelevel/sbt/TypelevelPlugin.scala
@@ -48,7 +48,6 @@ object TypelevelPlugin extends AutoPlugin {
   import TypelevelCiPlugin.autoImport._
   import TypelevelSettingsPlugin.autoImport._
   import TypelevelSonatypeCiReleasePlugin.autoImport._
-  import TypelevelVersioningPlugin.autoImport._
   import GenerativePlugin.autoImport._
   import GitHubActionsPlugin.autoImport._
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -31,7 +31,6 @@ Instead of using the super-plugins, for finer-grained control you can always add
 ### sbt-typelevel-sonatype
 `TypelevelSonatypePlugin`: Sets up publishing to Sonatype/Maven.
 
-- `tlSonatypeUseLegacyHost` (setting): Publish to `oss.sonatype.org` instead of `s01.oss.sonatype.org` (default: false).
 - `tlRelease` (command): Check binary-compatibility and `+publish` to Sonatype.
 
 `TypelevelUnidocPlugin`: Sets up publishing a Scaladoc-only artifact to Sonatype/Maven.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -87,14 +87,6 @@ val root = tlCrossRootProject
   .aggregate(core, io, node, scodec, protocols, reactiveStreams, benchmark)
 ```
 
-## How do I publish to `oss.sonatype.org` instead of `s01.oss.sonatype.org`?
-
-Note that `oss.sonatype.org` is the legacy host and there is an [open invitation to migrate to the new host](https://central.sonatype.org/news/20210223_new-users-on-s01/#why-are-we-doing-this).
-
-```scala
-ThisBuild / tlSonatypeUseLegacyHost := true
-```
-
 ## How do I publish a website like this one?
 
 Check out the [**sbt-typelevel-site**](site.md) plugin.

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,9 +78,6 @@ ThisBuild / developers ++= List(
   tlGitHubDev("armanbilge", "Arman Bilge")
 )
 
-// false by default, set to true to publish to oss.sonatype.org
-ThisBuild / tlSonatypeUseLegacyHost := false
-
 val Scala3 = "3.3.0"
 ThisBuild / crossScalaVersions := Seq("2.13.11", Scala3)
 ThisBuild / scalaVersion := Scala3 // the default Scala

--- a/docs/plugins.dot
+++ b/docs/plugins.dot
@@ -10,7 +10,6 @@ digraph {
   mdoc[label="sbt-mdoc"]
   mima[label="sbt-mima-plugin"]
   sncp[label="sbt-scala-native-crossproject"]
-  sonatype[label="sbt-sonatype"]
   sjs[label="sbt-scalajs"]
   sjscp[label="sbt-scalajs-crossproject"]
   unidoc[label="sbt-unidoc"]
@@ -41,7 +40,6 @@ digraph {
 
   tlsonatype[label="sbt-typelevel-sonatype"];
   tlsonatype -> tlkernel;
-  tlsonatype -> sonatype;
   tlsonatype -> mima;
   tlsonatype -> unidoc;
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -14,16 +14,13 @@ The instructions provided here are adapted from [sbt/sbt-ci-release](https://git
 
 If this is your first time publishing, first follow the [Initial Setup](https://central.sonatype.org/publish/publish-guide/#initial-setup) directions in Sonatype's [Publishing Guide](https://central.sonatype.org/publish/publish-guide/) to create an account and request publishing rights for your domain name. If you do not have a domain, you may use `io.github.your_gh_handle` as your **Group Id**.
 
-After you've been granted publishing rights for your domain, log in to either:
-
-- https://s01.oss.sonatype.org (all newly-registered domains)
-- https://oss.sonatype.org (domains registered before February 2021)
+After you've been granted publishing rights for your domain, log in [Sonatype Central Portal](https://central.sonatype.org/).
 
 Then:
 
-1. Click your username in the top right, then click **Profile**
-2. In the drop-down menu in the top left, select **User Token**
-3. Click the **Access User Token** button to obtain your Sonatype credentials
+1. Click your username in the top right, then click **View Account**
+2. Select **Generate User Token**
+3. Press **Ok** to (re)generate your user token.
 4. Set these as the `SONATYPE_USERNAME` and `SONATYPE_PASSWORD` secrets on your repository
 
 ## PGP Key

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -14,7 +14,7 @@ The instructions provided here are adapted from [sbt/sbt-ci-release](https://git
 
 If this is your first time publishing, first follow the [Initial Setup](https://central.sonatype.org/publish/publish-guide/#initial-setup) directions in Sonatype's [Publishing Guide](https://central.sonatype.org/publish/publish-guide/) to create an account and request publishing rights for your domain name. If you do not have a domain, you may use `io.github.your_gh_handle` as your **Group Id**.
 
-After you've been granted publishing rights for your domain, log in [Sonatype Central Portal](https://central.sonatype.org/).
+After you've been granted publishing rights for your domain, log in to [Sonatype Central Portal](https://central.sonatype.org/).
 
 Then:
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.11.0

--- a/sonatype-ci-release/src/main/scala/org/typelevel/sbt/TypelevelSonatypeCiReleasePlugin.scala
+++ b/sonatype-ci-release/src/main/scala/org/typelevel/sbt/TypelevelSonatypeCiReleasePlugin.scala
@@ -72,7 +72,7 @@ object TypelevelSonatypeCiReleasePlugin extends AutoPlugin {
   @nowarn("cat=deprecation")
   private def tlCiReleaseCommand: Command =
     Command.command("tlCiRelease") { state =>
-      val newState = Command.process("tlRelease", state)
+      val newState = Command.process("tlRelease", state,  _ => ())
       newState.getSetting(version).foreach { v =>
         val resolver = newState.getSetting(isSnapshot).fold("") {
           case true =>

--- a/sonatype-ci-release/src/main/scala/org/typelevel/sbt/TypelevelSonatypeCiReleasePlugin.scala
+++ b/sonatype-ci-release/src/main/scala/org/typelevel/sbt/TypelevelSonatypeCiReleasePlugin.scala
@@ -22,8 +22,6 @@ import org.typelevel.sbt.gha.GitHubActionsPlugin
 import sbt.Keys._
 import sbt._
 
-import scala.annotation.nowarn
-
 object TypelevelSonatypeCiReleasePlugin extends AutoPlugin {
 
   object autoImport {
@@ -69,7 +67,6 @@ object TypelevelSonatypeCiReleasePlugin extends AutoPlugin {
     .map(k => k -> s"$${{ secrets.$k }}")
     .toMap
 
-  @nowarn("cat=deprecation")
   private def tlCiReleaseCommand: Command =
     Command.command("tlCiRelease") { state =>
       val newState = Command.process("tlRelease", state, _ => ())

--- a/sonatype-ci-release/src/main/scala/org/typelevel/sbt/TypelevelSonatypeCiReleasePlugin.scala
+++ b/sonatype-ci-release/src/main/scala/org/typelevel/sbt/TypelevelSonatypeCiReleasePlugin.scala
@@ -72,7 +72,7 @@ object TypelevelSonatypeCiReleasePlugin extends AutoPlugin {
   @nowarn("cat=deprecation")
   private def tlCiReleaseCommand: Command =
     Command.command("tlCiRelease") { state =>
-      val newState = Command.process("tlRelease", state,  _ => ())
+      val newState = Command.process("tlRelease", state, _ => ())
       newState.getSetting(version).foreach { v =>
         val resolver = newState.getSetting(isSnapshot).fold("") {
           case true =>

--- a/sonatype-ci-release/src/main/scala/org/typelevel/sbt/TypelevelSonatypeCiReleasePlugin.scala
+++ b/sonatype-ci-release/src/main/scala/org/typelevel/sbt/TypelevelSonatypeCiReleasePlugin.scala
@@ -21,7 +21,8 @@ import org.typelevel.sbt.gha.GenerativePlugin.autoImport._
 import org.typelevel.sbt.gha.GitHubActionsPlugin
 import sbt.Keys._
 import sbt._
-import xerial.sbt.Sonatype.autoImport._
+
+import scala.annotation.nowarn
 
 object TypelevelSonatypeCiReleasePlugin extends AutoPlugin {
 
@@ -68,24 +69,20 @@ object TypelevelSonatypeCiReleasePlugin extends AutoPlugin {
     .map(k => k -> s"$${{ secrets.$k }}")
     .toMap
 
+  @nowarn("cat=deprecation")
   private def tlCiReleaseCommand: Command =
     Command.command("tlCiRelease") { state =>
       val newState = Command.process("tlRelease", state)
       newState.getSetting(version).foreach { v =>
-        val resolver = newState.getSetting(sonatypeDefaultResolver).fold("") {
-          case repo: MavenRepository =>
+        val resolver = newState.getSetting(isSnapshot).fold("") {
+          case true =>
             s"""|```scala
-                |resolvers += "${repo.name}" at "${repo.root}"
+                |resolvers += "central-snapshots" at "https://central.sonatype.com/repository/maven-snapshots/"
                 |```
                 |""".stripMargin
 
-          case repo: URLRepository =>
-            s"""|```scala
-                |resolvers += URLRepository("${repo.name}", ${repo.patterns}, ${repo.allowInsecureProtocol})
-                |```
-                |""".stripMargin
-          // fallback to print at least _something_
-          case other => other.toString
+          case false =>
+            ""
         }
 
         GitHubActionsPlugin.appendToStepSummary(

--- a/sonatype/build.sbt
+++ b/sonatype/build.sbt
@@ -1,3 +1,2 @@
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.4")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.12.2")
 addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")

--- a/sonatype/src/main/scala/org/typelevel/sbt/TypelevelSonatypePlugin.scala
+++ b/sonatype/src/main/scala/org/typelevel/sbt/TypelevelSonatypePlugin.scala
@@ -37,7 +37,7 @@ object TypelevelSonatypePlugin extends AutoPlugin {
         "project /",
         "+mimaReportBinaryIssues",
         "+publish",
-        "sonaRelease")
+        "tlSonatypeBundleReleaseIfRelevant")
     }
   )
 
@@ -53,6 +53,7 @@ object TypelevelSonatypePlugin extends AutoPlugin {
       if (isSnapshot.value) Some("central-snapshots" at centralSnapshots)
       else localStaging.value
     },
+    commands += sonatypeBundleReleaseIfRelevant,
     apiURL := apiURL.value.orElse(hostedApiUrl.value),
     sbtPluginPublishLegacyMavenStyle := false
   )
@@ -73,4 +74,12 @@ object TypelevelSonatypePlugin extends AutoPlugin {
           s"https://www.javadoc.io/doc/${organization.value}/${cross(moduleName.value)}/${version.value}/")
       }
   }
+
+  private def sonatypeBundleReleaseIfRelevant: Command =
+    Command.command("tlSonatypeBundleReleaseIfRelevant") { state =>
+      if (state.getSetting(isSnapshot).getOrElse(false))
+        state // a snapshot is good-to-go
+      else // a non-snapshot releases as a bundle
+        Command.process("sonaRelease", state, _ => ())
+    }
 }

--- a/sonatype/src/main/scala/org/typelevel/sbt/TypelevelSonatypePlugin.scala
+++ b/sonatype/src/main/scala/org/typelevel/sbt/TypelevelSonatypePlugin.scala
@@ -53,7 +53,8 @@ object TypelevelSonatypePlugin extends AutoPlugin {
       if (isSnapshot.value) Some("central-snapshots" at centralSnapshots)
       else localStaging.value
     },
-    apiURL := apiURL.value.orElse(hostedApiUrl.value)
+    apiURL := apiURL.value.orElse(hostedApiUrl.value),
+    sbtPluginPublishLegacyMavenStyle := false
   )
 
   private[sbt] lazy val hostedApiUrl =

--- a/sonatype/src/main/scala/org/typelevel/sbt/TypelevelSonatypePlugin.scala
+++ b/sonatype/src/main/scala/org/typelevel/sbt/TypelevelSonatypePlugin.scala
@@ -58,7 +58,7 @@ object TypelevelSonatypePlugin extends AutoPlugin {
   )
 
   private[sbt] lazy val hostedApiUrl =
-    Def.setting(javadocioUrl.value.orElse(sonatypeApiUrl.value))
+    Def.setting(javadocioUrl.value)
 
   private lazy val javadocioUrl = Def.setting {
     if (isSnapshot.value || !publishArtifact.value)
@@ -72,23 +72,5 @@ object TypelevelSonatypePlugin extends AutoPlugin {
         url(
           s"https://www.javadoc.io/doc/${organization.value}/${cross(moduleName.value)}/${version.value}/")
       }
-  }
-
-  private lazy val sonatypeApiUrl = Def.setting {
-    if (publishArtifact.value)
-      CrossVersion(
-        crossVersion.value,
-        scalaVersion.value,
-        scalaBinaryVersion.value
-      ).map { cross =>
-        val host = "central.sonatype.com"
-        val repo = if (isSnapshot.value) "snapshots" else "releases"
-        val org = organization.value.replace('.', '/')
-        val mod = cross(moduleName.value)
-        val ver = version.value
-        url(
-          s"https://$host/service/local/repositories/$repo/archive/$org/$mod/$ver/$mod-$ver-javadoc.jar/!/index.html")
-      }
-    else None
   }
 }

--- a/sonatype/src/main/scala/org/typelevel/sbt/TypelevelSonatypePlugin.scala
+++ b/sonatype/src/main/scala/org/typelevel/sbt/TypelevelSonatypePlugin.scala
@@ -19,8 +19,6 @@ package org.typelevel.sbt
 import com.typesafe.tools.mima.plugin.MimaPlugin
 import sbt._
 
-import scala.annotation.nowarn
-
 import Keys._
 import TypelevelKernelPlugin.autoImport._
 
@@ -31,8 +29,6 @@ object TypelevelSonatypePlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   object autoImport {}
-
-  import autoImport._
 
   override def globalSettings = Seq(
     tlCommandAliases += {


### PR DESCRIPTION
As [discussed](https://github.com/typelevel/sbt-typelevel/discussions/821), drops sbt-sonatype support in favor of the functionality built into sbt-1.11.0, in anticipation of the OSSRH sunset.