### PR TITLE
Switch to `windows-2022` runner tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-latest, windows-2022]
         scala: [2.12]
         java:
           - temurin@8
@@ -56,25 +56,25 @@ jobs:
           - java: temurin@11
             os: macos-latest
           - java: temurin@11
-            os: windows-latest
+            os: windows-2022
           - java: temurin@17
-            os: windows-latest
+            os: windows-2022
           - java: graal_22.3.2@11
             os: macos-latest
           - java: graal_22.3.2@11
-            os: windows-latest
+            os: windows-2022
           - java: graalvm@21
             os: macos-latest
           - java: graalvm@21
-            os: windows-latest
+            os: windows-2022
           - java: corretto@17
             os: macos-latest
           - java: corretto@17
-            os: windows-latest
+            os: windows-2022
           - java: semeru@17
             os: macos-latest
           - java: semeru@17
-            os: windows-latest
+            os: windows-2022
           - java: temurin@8
             os: macos-latest
     runs-on: ${{ matrix.os }}

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -20,7 +20,7 @@ pull_request_rules:
   - status-success=Test (ubuntu-22.04, 2.12, corretto@17, sbt-typelevelJVM)
   - status-success=Test (ubuntu-22.04, 2.12, semeru@17, sbt-typelevelJVM)
   - status-success=Test (macos-latest, 2.12, temurin@17, sbt-typelevelJVM)
-  - status-success=Test (windows-latest, 2.12, temurin@8, sbt-typelevelJVM)
+  - status-success=Test (windows-2022, 2.12, temurin@8, sbt-typelevelJVM)
   - status-success=Validate Steward Config (ubuntu-22.04, temurin@11)
   - status-success=Generate Site (ubuntu-22.04, temurin@11)
   - '#approved-reviews-by>=1'

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ ThisBuild / githubWorkflowJavaVersions ++= Seq(
 
 val macOS = "macos-latest"
 
-ThisBuild / githubWorkflowOSes ++= Seq(macOS, "windows-latest")
+ThisBuild / githubWorkflowOSes ++= Seq(macOS, "windows-2022")
 
 ThisBuild / githubWorkflowBuildMatrixExclusions ++= {
   val exclusions = for {


### PR DESCRIPTION
The `windows-latest` tag currently points to Windows Server 2022 but **it will be migrating to point to Windows Server 2025 starting on September 2 2025**

We can keep using the existing runner by switching to the `windows-2022` tag. This runner will have another 3 years of support and we can migrate in the future under less of a crunch. Please don't feel you have to accept this PR if you would rather make the switch now, I'm just trying to make sure maintainers are aware and not surprised like we all were with the ubuntu-latest changes.

Details about the runner change, and what other software changes are being made alongside, are documented here:
- https://github.com/actions/runner-images/issues/12677