### PR TITLE
Update the Scala Steward pin to a recent version

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,5 +1,5 @@
 updates.pin = [
-  { groupId = "org.scala-sbt", artifactId = "sbt", version = "1.9." },
+  { groupId = "org.scala-sbt", artifactId = "sbt", version = "1.11." },
   { groupId = "org.scala-lang", artifactId = "scala-library", version = "2.12." },
   { groupId = "org.scala-js", artifactId = "sbt-scalajs", version = "1.13." },
 ]


### PR DESCRIPTION
This version is already in use as it is required for Sonatype Central publishing