### PR TITLE
Suppress new warning about kind-polymorphic type inferred as Nothing …

### DIFF
--- a/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
+++ b/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
@@ -209,7 +209,7 @@ object TypelevelSettingsPlugin extends AutoPlugin {
     },
     scalacOptions ++= {
       scalaVersion.value match {
-        case V(V(2, 13, Some(17), _)) =>
+        case V(V(2, 13, Some(patch), _)) if patch >= 17 =>
           // https://github.com/scala/bug/issues/13128#issuecomment-3375870295
           Seq("-Wconf:cat=lint-infer-any&msg=kind-polymorphic:s")
         case _ =>


### PR DESCRIPTION
…due to high false positive rate in Typelevel-style code.

Implements @som-snytt's recommendation in https://github.com/scala/bug/issues/13128#issuecomment-3375870295.