### PR TITLE
Add opt-in support for TASTy-MiMa to check Scala 3 compatibility in CI

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -187,7 +187,13 @@ lazy val mima = project
   .in(file("mima"))
   .enablePlugins(SbtPlugin)
   .settings(
-    name := "sbt-typelevel-mima"
+    name := "sbt-typelevel-mima",
+    mimaBinaryIssueFilters ++= Seq(
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+        "org.typelevel.sbt.TypelevelMimaPlugin.requires"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "org.typelevel.sbt.TypelevelMimaPlugin.requires")
+    )
   )
   .dependsOn(kernel)
 

--- a/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
@@ -43,6 +43,8 @@ object TypelevelCiPlugin extends AutoPlugin {
       settingKey[Boolean]("Whether to do scalafix check in CI (default: false)")
     lazy val tlCiMimaBinaryIssueCheck =
       settingKey[Boolean]("Whether to do MiMa binary issues check in CI (default: false)")
+    lazy val tlCiTastyMimaCheck =
+      settingKey[Boolean]("Whether to do TASTy-MiMa issues check in CI (default: false)")
     lazy val tlCiDocCheck =
       settingKey[Boolean]("Whether to build API docs in CI (default: false)")
 
@@ -66,6 +68,7 @@ object TypelevelCiPlugin extends AutoPlugin {
     tlCiJavafmtCheck := false,
     tlCiScalafixCheck := false,
     tlCiMimaBinaryIssueCheck := false,
+    tlCiTastyMimaCheck := false,
     tlCiDocCheck := false,
     tlCiDependencyGraphJob := true,
     tlCiForkCondition := "github.event.repository.fork == false",
@@ -129,6 +132,16 @@ object TypelevelCiPlugin extends AutoPlugin {
             ))
         else Nil
 
+      val tastyMima =
+        if (tlCiTastyMimaCheck.value)
+          List(
+            WorkflowStep.Sbt(
+              List("tastyMiMaReportIssues"),
+              name = Some("Check TASTy compatibility"),
+              cond = Some(primaryAxisCond.value)
+            ))
+        else Nil
+
       val doc =
         if (tlCiDocCheck.value)
           List(
@@ -140,7 +153,7 @@ object TypelevelCiPlugin extends AutoPlugin {
           )
         else Nil
 
-      style ++ scalafix ++ test ++ mima ++ doc
+      style ++ scalafix ++ test ++ mima ++ tastyMima ++ doc
     },
     githubWorkflowJavaVersions := Seq(JavaSpec.temurin("8")),
     githubWorkflowAddedJobs ++= {

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -27,7 +27,6 @@ Instead of using the super-plugins, for finer-grained control you can always add
 
 - `tlVersionIntroduced` (setting): A map `scalaBinaryVersion -> version` e.g. `Map("2.13" -> "1.5.2", "3" -> "1.7.1")` used to indicate that a particular `crossScalaVersions` value was introduced in a given version (default: empty).
 - `tlMimaPreviousVersions` (setting): A set of previous versions to compare binary-compatibility against.
-- `tlTastyMima` (setting): Enable TASTy-MiMa (default: `false`).
 
 ### sbt-typelevel-sonatype
 `TypelevelSonatypePlugin`: Sets up publishing to Sonatype/Maven.

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -27,6 +27,7 @@ Instead of using the super-plugins, for finer-grained control you can always add
 
 - `tlVersionIntroduced` (setting): A map `scalaBinaryVersion -> version` e.g. `Map("2.13" -> "1.5.2", "3" -> "1.7.1")` used to indicate that a particular `crossScalaVersions` value was introduced in a given version (default: empty).
 - `tlMimaPreviousVersions` (setting): A set of previous versions to compare binary-compatibility against.
+- `tlTastyMima` (setting): Enable TASTy-MiMa (default: `false`).
 
 ### sbt-typelevel-sonatype
 `TypelevelSonatypePlugin`: Sets up publishing to Sonatype/Maven.
@@ -64,6 +65,7 @@ Both plugins are documented in [**sbt-typelevel-github-actions**](gha.md).
 - `tlCiJavafmtCheck` (setting): Whether to do javafmt check in CI (default: `false`).
 - `tlCiScalafixCheck` (setting): Whether to do scalafix check in CI (default: `false`).
 - `tlCiMimaBinaryIssueCheck` (setting): Whether to do MiMa binary issues check in CI (default: `false`).
+- `tlCiTastyMimaCheck` (setting): Whether to do TASTy-MiMa issues check in CI (default: `false`).
 - `tlCiDocCheck` (setting): Whether to build API docs in CI (default: `false`).
 - `tlCiDependencyGraphJob` (setting): Whether to add a job to submit dependencies to GH (default: `true`).
 - `tlCiForkCondition` (setting): Condition for checking on CI whether this project is a fork of another (default: `github.event.repository.fork == false`).

--- a/mima/build.sbt
+++ b/mima/build.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.5")
+addSbtPlugin("ch.epfl.scala" % "sbt-tasty-mima" % "1.4.0")

--- a/mima/src/main/scala/org/typelevel/sbt/TypelevelMimaPlugin.scala
+++ b/mima/src/main/scala/org/typelevel/sbt/TypelevelMimaPlugin.scala
@@ -17,16 +17,18 @@
 package org.typelevel.sbt
 
 import com.typesafe.tools.mima.plugin.MimaPlugin
+import sbttastymima.TastyMiMaPlugin
 import org.typelevel.sbt.kernel.GitHelper
 import org.typelevel.sbt.kernel.V
 import sbt._
 
 import Keys._
 import MimaPlugin.autoImport._
+import TastyMiMaPlugin.autoImport._
 
 object TypelevelMimaPlugin extends AutoPlugin {
 
-  override def requires = MimaPlugin
+  override def requires = MimaPlugin && TastyMiMaPlugin
 
   override def trigger = allRequirements
 
@@ -36,6 +38,7 @@ object TypelevelMimaPlugin extends AutoPlugin {
         "A map scalaBinaryVersion -> version e.g. Map('2.13' -> '1.5.2', '3' -> '1.7.1') used to indicate that a particular crossScalaVersions value was introduced in a given version (default: empty).")
     lazy val tlMimaPreviousVersions = settingKey[Set[String]](
       "A set of previous versions to compare binary-compatibility against (default: auto-populated from git tags and the tlVersionIntroduced setting)")
+    lazy val tlTastyMima = settingKey[Boolean]("Enable TASTy-MiMa (default: false)")
   }
 
   import autoImport._
@@ -85,6 +88,27 @@ object TypelevelMimaPlugin extends AutoPlugin {
         }
       else
         Set.empty
+    },
+    tlTastyMima := false,
+    tastyMiMaReportIssues := {
+      if (tlTastyMima.value && publishArtifact.value) tastyMiMaReportIssues.value
+      else ()
+    },
+    tastyMiMaPreviousArtifacts := {
+      if (tlTastyMima.value && publishArtifact.value) {
+        tlMimaPreviousVersions
+          .value
+          .flatMap(v => V(v))
+          .toList
+          .sorted
+          .lastOption
+          .map { v =>
+            projectID.value.withRevision(v.toString).withExplicitArtifacts(Vector.empty)
+          }
+          .toSet
+      } else {
+        Set.empty
+      }
     }
   )
 

--- a/mima/src/main/scala/org/typelevel/sbt/TypelevelMimaPlugin.scala
+++ b/mima/src/main/scala/org/typelevel/sbt/TypelevelMimaPlugin.scala
@@ -17,10 +17,10 @@
 package org.typelevel.sbt
 
 import com.typesafe.tools.mima.plugin.MimaPlugin
-import sbttastymima.TastyMiMaPlugin
 import org.typelevel.sbt.kernel.GitHelper
 import org.typelevel.sbt.kernel.V
 import sbt._
+import sbttastymima.TastyMiMaPlugin
 
 import Keys._
 import MimaPlugin.autoImport._

--- a/mima/src/main/scala/org/typelevel/sbt/TypelevelMimaPlugin.scala
+++ b/mima/src/main/scala/org/typelevel/sbt/TypelevelMimaPlugin.scala
@@ -25,10 +25,11 @@ import sbttastymima.TastyMiMaPlugin
 import Keys._
 import MimaPlugin.autoImport._
 import TastyMiMaPlugin.autoImport._
+import TypelevelKernelPlugin.autoImport._
 
 object TypelevelMimaPlugin extends AutoPlugin {
 
-  override def requires = MimaPlugin && TastyMiMaPlugin
+  override def requires = TypelevelKernelPlugin && MimaPlugin && TastyMiMaPlugin
 
   override def trigger = allRequirements
 
@@ -38,7 +39,6 @@ object TypelevelMimaPlugin extends AutoPlugin {
         "A map scalaBinaryVersion -> version e.g. Map('2.13' -> '1.5.2', '3' -> '1.7.1') used to indicate that a particular crossScalaVersions value was introduced in a given version (default: empty).")
     lazy val tlMimaPreviousVersions = settingKey[Set[String]](
       "A set of previous versions to compare binary-compatibility against (default: auto-populated from git tags and the tlVersionIntroduced setting)")
-    lazy val tlTastyMima = settingKey[Boolean]("Enable TASTy-MiMa (default: false)")
   }
 
   import autoImport._
@@ -89,13 +89,12 @@ object TypelevelMimaPlugin extends AutoPlugin {
       else
         Set.empty
     },
-    tlTastyMima := false,
     tastyMiMaReportIssues := {
-      if (tlTastyMima.value && publishArtifact.value) tastyMiMaReportIssues.value
+      if (tlIsScala3.value && publishArtifact.value) tastyMiMaReportIssues.value
       else ()
     },
     tastyMiMaPreviousArtifacts := {
-      if (tlTastyMima.value && publishArtifact.value) {
+      if (tlIsScala3.value && publishArtifact.value) {
         tlMimaPreviousVersions
           .value
           .flatMap(v => V(v))


### PR DESCRIPTION
Fixes #547 

i have added opt-in support for sbt-tasty-mima. now, Scala 3 projects can check for TASTy compatibility directly in CI. based on discussion in the issue, it currently defaults to false. it only checks against the latest previous version instead of the whole release history