### PR TITLE
Skip Scala.js sourcemap mapping when there are uncommitted changes

### DIFF
--- a/github/src/main/scala/org/typelevel/sbt/TypelevelScalaJSGitHubPlugin.scala
+++ b/github/src/main/scala/org/typelevel/sbt/TypelevelScalaJSGitHubPlugin.scala
@@ -35,7 +35,10 @@ object TypelevelScalaJSGitHubPlugin extends AutoPlugin {
       val flag = if (tlIsScala3.value) "-scalajs-mapSourceURI:" else "-P:scalajs:mapSourceURI:"
 
       val tagOrHash =
-        GitHelper.getTagOrHash(git.gitCurrentTags.value, git.gitHeadCommit.value)
+        GitHelper
+          .getTagOrHash(git.gitCurrentTags.value, git.gitHeadCommit.value)
+          // Don't include the flag if there are uncommitted changes, since the tag or hash would be inaccurate
+          .filterNot(_ => git.gitUncommittedChanges.value)
 
       val l = (LocalRootProject / baseDirectory).value.toURI.toString
 


### PR DESCRIPTION
Skips the `mapSourceURI` flag when there are uncommitted changes, since it will be very unlikely to map to a remote source.
Source maps can still not exist when the commit is not pushed, but this will at least prevent the source map from being completely broken during local development.
