### PR TITLE
Enable dependency-submission on same-repo pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,12 +394,25 @@ jobs:
 
   dependency-submission:
     name: Submit Dependencies
-    if: github.event.repository.fork == false && github.event_name != 'pull_request'
+    if: github.event.repository.fork == false && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     strategy:
       matrix:
         os: [ubuntu-22.04]
         java: [temurin@8]
     runs-on: ${{ matrix.os }}
+    permissions:
+      actions: none
+      checks: none
+      contents: write
+      deployments: none
+      id-token: none
+      issues: none
+      packages: read
+      pages: none
+      pull-requests: none
+      repository-projects: none
+      security-events: none
+      statuses: none
     steps:
       - name: Ignore line ending differences in git
         if: contains(runner.os, 'windows')

--- a/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
@@ -20,6 +20,8 @@ import org.typelevel.sbt.NoPublishGlobalPlugin.noPublishModulesIgnore
 import org.typelevel.sbt.gha.GenerativePlugin
 import org.typelevel.sbt.gha.GenerativePlugin.autoImport._
 import org.typelevel.sbt.gha.GitHubActionsPlugin
+import org.typelevel.sbt.gha.PermissionValue
+import org.typelevel.sbt.gha.Permissions
 import org.typelevel.sbt.gha.WorkflowStep
 import sbt._
 
@@ -49,6 +51,10 @@ object TypelevelCiPlugin extends AutoPlugin {
     lazy val tlCiDependencyGraphJob =
       settingKey[Boolean]("Whether to add a job to submit dependencies to GH (default: true)")
 
+    lazy val tlCiDependencyGraphOnPullRequest =
+      settingKey[Boolean](
+        "Whether to run the dependency-submission job on same-repo pull requests (default: true)")
+
     lazy val tlCiStewardValidateConfig = settingKey[Option[File]](
       "The location of the Scala Steward config to validate (default: `.scala-steward.conf`, if exists)")
 
@@ -68,6 +74,7 @@ object TypelevelCiPlugin extends AutoPlugin {
     tlCiMimaBinaryIssueCheck := false,
     tlCiDocCheck := false,
     tlCiDependencyGraphJob := true,
+    tlCiDependencyGraphOnPullRequest := true,
     tlCiForkCondition := "github.event.repository.fork == false",
     githubWorkflowTargetBranches ++= Seq(
       "!update/**", // ignore steward branches
@@ -144,8 +151,14 @@ object TypelevelCiPlugin extends AutoPlugin {
     },
     githubWorkflowJavaVersions := Seq(JavaSpec.temurin("8")),
     githubWorkflowAddedJobs ++= {
-      val ghEventCond = "github.event_name != 'pull_request'"
-      val jobCond = s"${tlCiForkCondition.value} && $ghEventCond"
+      val sameRepoPrCond =
+        "github.event.pull_request.head.repo.full_name == github.repository"
+      val ghEventCond =
+        if (tlCiDependencyGraphOnPullRequest.value)
+          s"github.event_name != 'pull_request' || $sameRepoPrCond"
+        else
+          "github.event_name != 'pull_request'"
+      val jobCond = s"${tlCiForkCondition.value} && ($ghEventCond)"
 
       val dependencySubmission =
         if (tlCiDependencyGraphJob.value)
@@ -163,7 +176,9 @@ object TypelevelCiPlugin extends AutoPlugin {
                   Some(List("test", "scala-tool", "scala-doc-tool", "test-internal")),
                   None
                 ),
-              cond = Some(jobCond)
+              cond = Some(jobCond),
+              permissions =
+                Some(Permissions.Specify.defaultRestrictive.withContents(PermissionValue.Write))
             ))
         else Nil
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -66,6 +66,7 @@ Both plugins are documented in [**sbt-typelevel-github-actions**](gha.md).
 - `tlCiMimaBinaryIssueCheck` (setting): Whether to do MiMa binary issues check in CI (default: `false`).
 - `tlCiDocCheck` (setting): Whether to build API docs in CI (default: `false`).
 - `tlCiDependencyGraphJob` (setting): Whether to add a job to submit dependencies to GH (default: `true`).
+- `tlCiDependencyGraphOnPullRequest` (setting): Whether to run the dependency-submission job on same-repo pull requests, enabling Dependabot/Dependency Review feedback before merge (default: `true`). Fork PRs are always excluded.
 - `tlCiForkCondition` (setting): Condition for checking on CI whether this project is a fork of another (default: `github.event.repository.fork == false`).
 - `tlCiStewardValidateConfig` (setting): The location of the Scala Steward config to validate (default: `.scala-steward.conf`, if exists).
 - `tlCrossRootProject` (method): helper to create a `root` project that can aggregate both `Project`s and `CrossProject`s. Automatically creates separate jobs in the CI matrix for each platform (JVM, JS, etc.).

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -66,7 +66,7 @@ Both plugins are documented in [**sbt-typelevel-github-actions**](gha.md).
 - `tlCiMimaBinaryIssueCheck` (setting): Whether to do MiMa binary issues check in CI (default: `false`).
 - `tlCiDocCheck` (setting): Whether to build API docs in CI (default: `false`).
 - `tlCiDependencyGraphJob` (setting): Whether to add a job to submit dependencies to GH (default: `true`).
-- `tlCiDependencyGraphOnPullRequest` (setting): Whether to run the dependency-submission job on same-repo pull requests, enabling Dependabot/Dependency Review feedback before merge (default: `true`). Fork PRs are always excluded.
+- `tlCiDependencyGraphOnPullRequest` (setting): Whether to run the dependency-submission job on same-repo pull requests (default: `true`).
 - `tlCiForkCondition` (setting): Condition for checking on CI whether this project is a fork of another (default: `github.event.repository.fork == false`).
 - `tlCiStewardValidateConfig` (setting): The location of the Scala Steward config to validate (default: `.scala-steward.conf`, if exists).
 - `tlCrossRootProject` (method): helper to create a `root` project that can aggregate both `Project`s and `CrossProject`s. Automatically creates separate jobs in the CI matrix for each platform (JVM, JS, etc.).


### PR DESCRIPTION
The dependency-submission job currently only runs on push, so vulnerabilities are only detected after merge. This PR enables it for same-repo PRs too, so projects can catch vulnerable dependencies before merging.

Fork PRs are still excluded because their read-only token can't call the Submission API.

Refs: #340, #342