### PR TITLE
Replace `sbt-gpg` with `sbt-pgp`

### DIFF
--- a/ci-signing/build.sbt
+++ b/ci-signing/build.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("io.crashbox" % "sbt-gpg" % "0.2.1")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.1")

--- a/ci-signing/build.sbt
+++ b/ci-signing/build.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.1")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.2")

--- a/ci-signing/src/main/scala/org/typelevel/sbt/TypelevelCiSigningPlugin.scala
+++ b/ci-signing/src/main/scala/org/typelevel/sbt/TypelevelCiSigningPlugin.scala
@@ -16,17 +16,16 @@
 
 package org.typelevel.sbt
 
-import io.crashbox.gpg.SbtGpg
+import com.jsuereth.sbtpgp.SbtPgp
+import com.jsuereth.sbtpgp.SbtPgp.autoImport.useGpgAgent
 import org.typelevel.sbt.gha.GenerativePlugin
 import org.typelevel.sbt.gha.GenerativePlugin.autoImport._
 import org.typelevel.sbt.gha.GitHubActionsPlugin
 import sbt._
 
-import Keys._
-
 object TypelevelCiSigningPlugin extends AutoPlugin {
 
-  override def requires = SbtGpg && GitHubActionsPlugin && GenerativePlugin
+  override def requires = SbtPgp && GitHubActionsPlugin && GenerativePlugin
 
   override def trigger = allRequirements
 
@@ -55,10 +54,8 @@ object TypelevelCiSigningPlugin extends AutoPlugin {
     )
   )
 
-  import SbtGpg.autoImport._
-
   override def projectSettings = Seq(
-    gpgWarnOnFailure := isSnapshot.value
+    useGpgAgent := false
   )
 
   private val env = Map(

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -14,7 +14,7 @@ Instead of using the super-plugins, for finer-grained control you can always add
 
 - `tlIsScala3` (setting): `true`, if `scalaVersion` is 3.x.
 - `tlCommandAliases` (setting): Command aliases defined for this build.
-- `tlReleaseLocal` (command): Alias for `+publishLocal`.
+- `tlReleaseLocal` (command): Alias for `+publishLocalSigned`.
 
 ### sbt-typelevel-versioning
 `TypelevelVersioningPlugin`: Establishes a git-based, early semantic versioning scheme.
@@ -31,7 +31,7 @@ Instead of using the super-plugins, for finer-grained control you can always add
 ### sbt-typelevel-sonatype
 `TypelevelSonatypePlugin`: Sets up publishing to Sonatype/Maven.
 
-- `tlRelease` (command): Check binary-compatibility and `+publish` to Sonatype.
+- `tlRelease` (command): Check binary-compatibility and `+publishSigned` to Sonatype.
 
 `TypelevelUnidocPlugin`: Sets up publishing a Scaladoc-only artifact to Sonatype/Maven.
 

--- a/docs/plugins.dot
+++ b/docs/plugins.dot
@@ -4,7 +4,7 @@ digraph {
   fix[label="sbt-scalafix"]
   fmt[label="sbt-scalafmt"]
   git[label="sbt-git"]
-  gpg[label="sbt-gpg"]
+  pgp[label="sbt-pgp"]
   header[label="sbt-header"]
   laika[label="laika-sbt"]
   mdoc[label="sbt-mdoc"]
@@ -47,7 +47,7 @@ digraph {
 
   tlcisigning[label="sbt-typelevel-ci-signing"];
   tlcisigning -> tlgha;
-  tlcisigning -> gpg;
+  tlcisigning -> pgp;
 
   tlsonatypecirelease[label="sbt-typelevel-sonatype-ci-release"];
   tlsonatypecirelease -> tlsonatype;

--- a/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
+++ b/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
@@ -62,7 +62,7 @@ object TypelevelKernelPlugin extends AutoPlugin {
   override def globalSettings = Seq(
     Def.derive(tlIsScala3 := scalaVersion.value.startsWith("3.")),
     tlCommandAliases := Map(
-      "tlReleaseLocal" -> List("reload", "project /", "+publishLocal")
+      "tlReleaseLocal" -> List("reload", "project /", "+publishLocalSigned")
     ),
     onLoad := {
       val aliases = tlCommandAliases.value

--- a/sonatype/build.sbt
+++ b/sonatype/build.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.6")
 addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.6.1")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.1")

--- a/sonatype/src/main/scala/org/typelevel/sbt/TypelevelSonatypePlugin.scala
+++ b/sonatype/src/main/scala/org/typelevel/sbt/TypelevelSonatypePlugin.scala
@@ -36,7 +36,7 @@ object TypelevelSonatypePlugin extends AutoPlugin {
         "reload",
         "project /",
         "+mimaReportBinaryIssues",
-        "+publish",
+        "+publishSigned",
         "tlSonatypeBundleReleaseIfRelevant")
     }
   )


### PR DESCRIPTION
## Motivation
See https://github.com/typelevel/sbt-typelevel/issues/899.

The [sbt-gpg](https://github.com/jodersky/sbt-gpg) plugin has no commits for the past five years. It's a minimal wrapper over the installed `gpg` command. Recent versions of [sbt-pgp](https://github.com/sbt/sbt-pgp) are also wrappers over `gpg` and support SBT 2.

This PR migrates to `sbt-pgp`. It replaces `sbt-gpg` completely. If needed, we could cross-build `ciSigning` with `sbt-pgp` for SBT 2. An alternative is to port the `sbt-gpg` logic directly into `ciSigning`, or uplift `sbt-gpg`. All approaches are up for discussion.

## Changes to downstream projects

Assuming that downstream projects publish in CI via `tlCiRelase`, there should be no major changes. Both plugins use the same command to sign artifacts.

There are a few differences:

 - `sbt-gpg` permitted unsigned snapshot artifacts when `gpg` keys were missing. With `sbt-pgp`, snapshots also have to be signed. This shouldn't affect downstream projects, as they should sign snapshot artifacts anyway.
 - `sbt-gpg` modified the `publish` task to use signed artifacts. `sbt-pgp` introduces a new `publishSigned` task. `publish`-specific settings (e.g. `publish / foo`) won't necessarily apply. I haven't found any downstream OSS projects that need this, but it's worth bearing in mind. `publish / skip` is re-used, so the `NoPublish` plugin works fine.
 - Both `gpg` commands are mostly the same, however `sbt-gpg` adds a `--yes` option. I don't think this should make a difference, as there shouldn't be any questions asked.
 - `sbt-gpg` exposes a few settings (`gpgCommand`, `gpgOptions` etc.). I haven't found any downstream OSS projects that use these.
 - `sbt-pgp` pulls in dependencies on bouncycastle and gigahorse. These are not used by default.

## Testing

I've verified that `tlReleaseLocal` produces the same signed artifacts as before. I think we'd need to actually publish an artifact to check the `tlCiRelease` flow.
