### PR TITLE
Cross build modules for SBT 2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -146,7 +146,8 @@ lazy val noPublish = project
   .in(file("no-publish"))
   .enablePlugins(SbtPlugin)
   .settings(
-    name := "sbt-typelevel-no-publish"
+    name := "sbt-typelevel-no-publish",
+    sbt2Settings
   )
 
 lazy val settings = project

--- a/build.sbt
+++ b/build.sbt
@@ -193,7 +193,8 @@ lazy val versioning = project
   .in(file("versioning"))
   .enablePlugins(SbtPlugin)
   .settings(
-    name := "sbt-typelevel-versioning"
+    name := "sbt-typelevel-versioning",
+    sbt2Settings
   )
   .dependsOn(kernel)
 

--- a/build.sbt
+++ b/build.sbt
@@ -202,7 +202,8 @@ lazy val mima = project
   .in(file("mima"))
   .enablePlugins(SbtPlugin)
   .settings(
-    name := "sbt-typelevel-mima"
+    name := "sbt-typelevel-mima",
+    sbt2Settings
   )
   .dependsOn(kernel)
 

--- a/build.sbt
+++ b/build.sbt
@@ -247,7 +247,8 @@ lazy val ci = project
   .in(file("ci"))
   .enablePlugins(SbtPlugin)
   .settings(
-    name := "sbt-typelevel-ci"
+    name := "sbt-typelevel-ci",
+    sbt2Settings
   )
   .dependsOn(noPublish, kernel, githubActions)
 

--- a/build.sbt
+++ b/build.sbt
@@ -221,7 +221,8 @@ lazy val scalafix = project
   .enablePlugins(SbtPlugin)
   .settings(
     name := "sbt-typelevel-scalafix",
-    tlVersionIntroduced := Map("2.12" -> "0.4.10")
+    tlVersionIntroduced := Map("2.12" -> "0.4.10"),
+    sbt2Settings
   )
   .dependsOn(noPublish)
 

--- a/build.sbt
+++ b/build.sbt
@@ -289,7 +289,8 @@ lazy val unidoc = project
   .in(file("unidoc"))
   .enablePlugins(TypelevelUnidocPlugin)
   .settings(
-    name := "sbt-typelevel-docs"
+    name := "sbt-typelevel-docs",
+    sbt2Settings
   )
 
 lazy val docs = project

--- a/build.sbt
+++ b/build.sbt
@@ -211,7 +211,8 @@ lazy val sonatype = project
   .in(file("sonatype"))
   .enablePlugins(SbtPlugin)
   .settings(
-    name := "sbt-typelevel-sonatype"
+    name := "sbt-typelevel-sonatype",
+    sbt2Settings
   )
   .dependsOn(kernel)
 

--- a/build.sbt
+++ b/build.sbt
@@ -237,7 +237,8 @@ lazy val sonatypeCiRelease = project
   .in(file("sonatype-ci-release"))
   .enablePlugins(SbtPlugin)
   .settings(
-    name := "sbt-typelevel-sonatype-ci-release"
+    name := "sbt-typelevel-sonatype-ci-release",
+    sbt2Settings
   )
   .dependsOn(sonatype, githubActions)
 

--- a/build.sbt
+++ b/build.sbt
@@ -176,7 +176,8 @@ lazy val githubActions = project
       ProblemFilters.exclude[DirectMissingMethodProblem]("org.typelevel.sbt.gha.*#*#Impl.*"),
       ProblemFilters.exclude[MissingTypesProblem]("org.typelevel.sbt.gha.*$Impl$"),
       ProblemFilters.exclude[MissingTypesProblem]("org.typelevel.sbt.gha.*$*$Impl$")
-    )
+    ),
+    sbt2Settings
   )
 
 lazy val mergify = project

--- a/build.sbt
+++ b/build.sbt
@@ -122,12 +122,24 @@ lazy val `sbt-typelevel` = tlCrossRootProject.aggregate(
   docs
 )
 
+lazy val sbt2Settings = Seq(
+  scalaVersion := "2.12.21",
+  crossScalaVersions := Seq("2.12.21", "3.8.3"),
+  (pluginCrossBuild / sbtVersion) := {
+    scalaBinaryVersion.value match {
+      case "2.12" => "1.5.8"
+      case _ => "2.0.0-RC13"
+    }
+  }
+)
+
 lazy val kernel = project
   .in(file("kernel"))
   .enablePlugins(SbtPlugin)
   .settings(
     name := "sbt-typelevel-kernel",
-    libraryDependencies += "org.scalameta" %% "munit" % MunitVersion % Test
+    libraryDependencies += "org.scalameta" %% "munit" % MunitVersion % Test,
+    sbt2Settings
   )
 
 lazy val noPublish = project

--- a/build.sbt
+++ b/build.sbt
@@ -187,7 +187,8 @@ lazy val mergify = project
   .enablePlugins(SbtPlugin)
   .settings(
     name := "sbt-typelevel-mergify",
-    tlVersionIntroduced := Map("2.12" -> "0.4.6")
+    tlVersionIntroduced := Map("2.12" -> "0.4.6"),
+    sbt2Settings
   )
   .dependsOn(githubActions)
 
@@ -308,7 +309,8 @@ lazy val sbt2 = project
     sonatypeCiRelease,
     ci,
     githubActions
-  ).settings(
+  )
+  .settings(
     scalaVersion := "3.8.3",
     ThisBuild / version := "1.1.1"
   )

--- a/build.sbt
+++ b/build.sbt
@@ -154,7 +154,8 @@ lazy val settings = project
   .in(file("settings"))
   .enablePlugins(SbtPlugin)
   .settings(
-    name := "sbt-typelevel-settings"
+    name := "sbt-typelevel-settings",
+    sbt2Settings
   )
   .dependsOn(kernel)
 

--- a/build.sbt
+++ b/build.sbt
@@ -127,7 +127,7 @@ lazy val sbt2Settings = Seq(
   crossScalaVersions := Seq("2.12.21", "3.8.3"),
   (pluginCrossBuild / sbtVersion) := {
     scalaBinaryVersion.value match {
-      case "2.12" => "1.5.8"
+      case "2.12" => "1.11.7"
       case _ => "2.0.0-RC13"
     }
   }
@@ -293,6 +293,22 @@ lazy val unidoc = project
   .settings(
     name := "sbt-typelevel-docs",
     sbt2Settings
+  )
+
+lazy val sbt2 = project
+  .in(file("sbt2"))
+  .aggregate(
+    kernel,
+    mima,
+    noPublish,
+    versioning,
+    sonatype,
+    sonatypeCiRelease,
+    ci,
+    githubActions
+  ).settings(
+    scalaVersion := "3.8.3",
+    ThisBuild / version := "1.1.1"
   )
 
 lazy val docs = project

--- a/build.sbt
+++ b/build.sbt
@@ -162,7 +162,8 @@ lazy val github = project
   .in(file("github"))
   .enablePlugins(SbtPlugin)
   .settings(
-    name := "sbt-typelevel-github"
+    name := "sbt-typelevel-github",
+    sbt2Settings
   )
   .dependsOn(kernel)
 

--- a/ci/src/main/scala-2.12/org/typelevel/sbt/CrossRootProjectMacros.scala
+++ b/ci/src/main/scala-2.12/org/typelevel/sbt/CrossRootProjectMacros.scala
@@ -17,7 +17,12 @@
 package org.typelevel.sbt
 
 import scala.annotation.tailrec
+import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
+
+trait CrossRootProjectMacros {
+  def tlCrossRootProject: CrossRootProject = macro CrossRootProjectMacros.crossRootProjectImpl
+}
 
 private[sbt] object CrossRootProjectMacros {
 

--- a/ci/src/main/scala-3/org/typelevel/sbt/CrossRootProjectMacros.scala
+++ b/ci/src/main/scala-3/org/typelevel/sbt/CrossRootProjectMacros.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.sbt
+import scala.quoted.*
+import scala.annotation.tailrec
+
+private[sbt] trait CrossRootProjectMacros {
+  inline def tlCrossRootProject: CrossRootProject = ${ CrossRootProjectMacros.crossRootProjectImpl }
+}
+
+private[sbt] object CrossRootProjectMacros {
+  def crossRootProjectImpl(using Quotes): Expr[CrossRootProject] =
+    val name = definingValName
+    '{ CrossRootProject($name) }
+
+  private def definingValName(using q: Quotes): Expr[String] =
+    val term = enclosingTerm
+    if term.isValDef then Expr(term.name)
+    else q.reflect.report.errorAndAbort(errorMsg)
+
+  private def enclosingTerm(using qctx: Quotes) =
+    import qctx.reflect.*
+    @tailrec
+    def enclosingTerm0(sym: Symbol): Symbol =
+      sym match
+        case sym if sym.flags.is(Flags.Macro)     => enclosingTerm0(sym.owner)
+        case sym if sym.flags.is(Flags.Synthetic) => enclosingTerm0(sym.owner)
+        case sym if !sym.isTerm                   => enclosingTerm0(sym.owner)
+        case _                                    => sym
+    enclosingTerm0(Symbol.spliceOwner)
+
+  private def errorMsg: String = "tlCrossRootProject must be directly assigned to a val, such as `val x = tlCrossRootProject`. Alternatively, you can use `org.typelevel.sbt.CrossRootProject.apply`"
+}

--- a/ci/src/main/scala/org/typelevel/sbt/CrossRootProject.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/CrossRootProject.scala
@@ -36,23 +36,23 @@ final class CrossRootProject private (
 
   def settings(ss: Def.SettingsDefinition*): CrossRootProject =
     new CrossRootProject(
-      all.settings(ss: _*),
-      jvm.settings(ss: _*),
-      js.settings(ss: _*),
-      native.settings(ss: _*)
+      all.settings(ss*),
+      jvm.settings(ss*),
+      js.settings(ss*),
+      native.settings(ss*)
     )
 
   def configure(transforms: (Project => Project)*): CrossRootProject =
     new CrossRootProject(
-      all.configure(transforms: _*),
-      jvm.configure(transforms: _*),
-      js.configure(transforms: _*),
-      native.configure(transforms: _*)
+      all.configure(transforms*),
+      jvm.configure(transforms*),
+      js.configure(transforms*),
+      native.configure(transforms*)
     )
 
   def configureRoot(transforms: (Project => Project)*): CrossRootProject =
     new CrossRootProject(
-      all.configure(transforms: _*),
+      all.configure(transforms*),
       jvm,
       js,
       native
@@ -61,7 +61,7 @@ final class CrossRootProject private (
   def configureJVM(transforms: (Project => Project)*): CrossRootProject =
     new CrossRootProject(
       all,
-      jvm.configure(transforms: _*),
+      jvm.configure(transforms*),
       js,
       native
     )
@@ -70,7 +70,7 @@ final class CrossRootProject private (
     new CrossRootProject(
       all,
       jvm,
-      js.configure(transforms: _*),
+      js.configure(transforms*),
       native
     )
 
@@ -79,27 +79,27 @@ final class CrossRootProject private (
       all,
       jvm,
       js,
-      native.configure(transforms: _*)
+      native.configure(transforms*)
     )
 
   def enablePlugins(ns: Plugins*): CrossRootProject =
     new CrossRootProject(
-      all.enablePlugins(ns: _*),
-      jvm.enablePlugins(ns: _*),
-      js.enablePlugins(ns: _*),
-      native.enablePlugins(ns: _*)
+      all.enablePlugins(ns*),
+      jvm.enablePlugins(ns*),
+      js.enablePlugins(ns*),
+      native.enablePlugins(ns*)
     )
 
   def disablePlugins(ps: AutoPlugin*): CrossRootProject =
     new CrossRootProject(
-      all.disablePlugins(ps: _*),
-      jvm.disablePlugins(ps: _*),
-      js.disablePlugins(ps: _*),
-      native.disablePlugins(ps: _*)
+      all.disablePlugins(ps*),
+      jvm.disablePlugins(ps*),
+      js.disablePlugins(ps*),
+      native.disablePlugins(ps*)
     )
 
   def aggregate(projects: CompositeProject*): CrossRootProject =
-    aggregateImpl(projects.flatMap(_.componentProjects): _*)
+    aggregateImpl(projects.flatMap(_.componentProjects)*)
 
   private def aggregateImpl(projects: Project*): CrossRootProject = {
     val jsProjects =
@@ -112,16 +112,19 @@ final class CrossRootProject private (
     val jvmProjects = projects.diff(jsProjects).diff(nativeProjects)
 
     new CrossRootProject(
-      all.aggregate(projects.map(_.project): _*),
+      all.aggregate(projects.map(p => LocalProject(p.id))*),
       if (jvmProjects.nonEmpty)
-        jvm.aggregate(jvmProjects.map(_.project): _*).enablePlugins(TypelevelCiJVMPlugin)
+        jvm
+          .aggregate(jvmProjects.map(p => LocalProject(p.id))*)
+          .enablePlugins(TypelevelCiJVMPlugin)
       else jvm,
       if (jsProjects.nonEmpty)
-        js.aggregate(jsProjects.map(_.project): _*).enablePlugins(TypelevelCiJSPlugin)
+        js.aggregate(jsProjects.map(p => LocalProject(p.id))*)
+          .enablePlugins(TypelevelCiJSPlugin)
       else js,
       if (nativeProjects.nonEmpty)
         native
-          .aggregate(nativeProjects.map(_.project): _*)
+          .aggregate(nativeProjects.map(p => LocalProject(p.id))*)
           .enablePlugins(TypelevelCiNativePlugin)
       else native
     )
@@ -169,7 +172,7 @@ object TypelevelCiCrossPlugin extends AutoPlugin {
 object TypelevelCiJVMPlugin extends AutoPlugin with RootProjectId {
   override def requires = TypelevelCiCrossPlugin
 
-  override def buildSettings: Seq[Setting[_]] = Seq(
+  override def buildSettings: Seq[Setting[?]] = Seq(
     githubWorkflowBuildMatrixAdditions := {
       val matrix = githubWorkflowBuildMatrixAdditions.value
       matrix.updated("project", matrix("project") ::: s"${rootProjectId.value}JVM" :: Nil)
@@ -180,7 +183,7 @@ object TypelevelCiJVMPlugin extends AutoPlugin with RootProjectId {
 object TypelevelCiJSPlugin extends AutoPlugin with RootProjectId {
   override def requires = TypelevelCiCrossPlugin
 
-  override def buildSettings: Seq[Setting[_]] = Seq(
+  override def buildSettings: Seq[Setting[?]] = Seq(
     githubWorkflowBuildMatrixAdditions := {
       val matrix = githubWorkflowBuildMatrixAdditions.value
       matrix.updated("project", matrix("project") ::: s"${rootProjectId.value}JS" :: Nil)
@@ -211,7 +214,7 @@ object TypelevelCiJSPlugin extends AutoPlugin with RootProjectId {
 object TypelevelCiNativePlugin extends AutoPlugin with RootProjectId {
   override def requires = TypelevelCiCrossPlugin
 
-  override def buildSettings: Seq[Setting[_]] = Seq(
+  override def buildSettings: Seq[Setting[?]] = Seq(
     githubWorkflowBuildMatrixAdditions := {
       val matrix = githubWorkflowBuildMatrixAdditions.value
       matrix.updated("project", matrix("project") ::: s"${rootProjectId.value}Native" :: Nil)

--- a/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/TypelevelCiPlugin.scala
@@ -22,17 +22,14 @@ import org.typelevel.sbt.gha.GenerativePlugin.autoImport._
 import org.typelevel.sbt.gha.GitHubActionsPlugin
 import org.typelevel.sbt.gha.WorkflowStep
 import sbt._
-
-import scala.language.experimental.macros
+import sbtcompat.PluginCompat._
 
 object TypelevelCiPlugin extends AutoPlugin {
 
   override def requires = GitHubActionsPlugin && GenerativePlugin
   override def trigger = allRequirements
 
-  object autoImport {
-    def tlCrossRootProject: CrossRootProject = macro CrossRootProjectMacros.crossRootProjectImpl
-
+  object autoImport extends CrossRootProjectMacros {
     lazy val tlCiHeaderCheck =
       settingKey[Boolean]("Whether to do header check in CI (default: false)")
     lazy val tlCiScalafmtCheck =
@@ -190,23 +187,55 @@ object TypelevelCiPlugin extends AutoPlugin {
     }
   )
 
-  override def projectSettings: Seq[Setting[_]] = Seq(
-    Test / Keys.executeTests := {
-      val results: Tests.Output = (Test / Keys.executeTests).value
+  override def projectSettings: Seq[Setting[?]] = Seq(
+    Test / Keys.executeTests := Def.uncached {
+      val results = (Test / Keys.executeTests).value
+      val events = results.events.map {
+        case (id, v) =>
+          (
+            id,
+            SuiteResult(
+              v.result,
+              v.passedCount,
+              v.failureCount,
+              v.errorCount,
+              v.skippedCount,
+              v.ignoredCount,
+              v.canceledCount,
+              v.pendingCount
+            ))
+      }
       GitHubActionsPlugin.appendToStepSummary(
-        renderTestResults(Keys.thisProject.value.id, Keys.scalaVersion.value, results)
+        renderTestResults(
+          Keys.thisProject.value.id,
+          Keys.scalaVersion.value,
+          results.overall,
+          events)
       )
       results
     }
   )
 
+  case class SuiteResult(
+      result: TestResult,
+      passedCount: Int,
+      failureCount: Int,
+      errorCount: Int,
+      skippedCount: Int,
+      ignoredCount: Int,
+      canceledCount: Int,
+      pendingCount: Int
+  )
+
   private def renderTestResults(
       projectName: String,
       scalaVersion: String,
-      results: Tests.Output): String = {
+      overall: TestResult,
+      events: Map[String, SuiteResult]
+  ): String = {
 
     val testHeader: String =
-      s"""|### ${projectName} Tests Results: ${results.overall}
+      s"""|### ${projectName} Tests Results: ${overall}
           |To run them locally use `++${scalaVersion} ${projectName}/test`
           |""".stripMargin
 
@@ -217,7 +246,7 @@ object TypelevelCiPlugin extends AutoPlugin {
           ||-:|-|-|-|-|-|-|-|-|
           |""".stripMargin
 
-    val tableBody = results.events.map {
+    val tableBody = events.map {
       case (suiteName, suiteResult) =>
         List(
           suiteName,
@@ -234,7 +263,7 @@ object TypelevelCiPlugin extends AutoPlugin {
 
     val table: String = tableBody.mkString(tableHeader, "\n", "\n</details>\n\n")
 
-    if (results.events.nonEmpty)
+    if (events.nonEmpty)
       testHeader + table
     else ""
   }

--- a/github-actions/build.sbt
+++ b/github-actions/build.sbt
@@ -1,1 +1,2 @@
 libraryDependencies += "org.yaml" % "snakeyaml" % "1.33"
+addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0")

--- a/github-actions/src/main/scala-2.12/org/typelevel/sbt/gha/PluginCompat.scala
+++ b/github-actions/src/main/scala-2.12/org/typelevel/sbt/gha/PluginCompat.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.sbt.gha
+
+import sbt._
+import sbtcompat.PluginCompat._
+import sjsonnew.JsonFormat
+object PluginCompat {
+  import CacheImplicits.*
+  val fileRefJsonFormat: JsonFormat[FileRef] = implicitly
+}

--- a/github-actions/src/main/scala-3/org/typelevel/sbt/gha/PluginCompat.scala
+++ b/github-actions/src/main/scala-3/org/typelevel/sbt/gha/PluginCompat.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.sbt.gha
+
+import sbt.*
+import sbtcompat.PluginCompat.*
+import sjsonnew.JsonFormat
+object PluginCompat {
+  import CacheImplicits.given
+  val fileRefJsonFormat: JsonFormat[FileRef] = summon
+}

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativePlugin.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativePlugin.scala
@@ -18,10 +18,11 @@ package org.typelevel.sbt.gha
 
 import sbt.Keys._
 import sbt._
+import sbtcompat.PluginCompat._
 
 import java.nio.file.FileSystems
 import scala.io.Source
-
+// TODO: Zainab - How can this be cross-built?
 object GenerativePlugin extends AutoPlugin {
 
   override def requires = plugins.JvmPlugin
@@ -702,7 +703,6 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}
   private lazy val internalTargetAggregation =
     settingKey[Seq[File]]("Aggregates target directories from all subprojects")
 
-  private val macosGuard = Some("contains(runner.os, 'macos')")
   private val windowsGuard = Some("contains(runner.os, 'windows')")
 
   private val PlatformSep = FileSystems.getDefault.getSeparator
@@ -911,7 +911,7 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}
     }
   }
 
-  private val generateCiContents = Def task {
+  private val generateCiContents: Def.Initialize[Task[String]] = Def task {
     compileWorkflow(
       "Continuous Integration",
       githubWorkflowTargetBranches.value.toList,
@@ -926,7 +926,7 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}
     )
   }
 
-  private val readCleanContents = Def task {
+  private val readCleanContents: Def.Initialize[Task[String]] = Def task {
     val src = Source.fromURL(getClass.getResource("/clean.yml"))
     try {
       src.mkString
@@ -935,28 +935,18 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}
     }
   }
 
-  private val workflowsDirTask = Def task {
-    val githubDir = baseDirectory.value / ".github"
-    val workflowsDir = githubDir / "workflows"
-
-    if (!githubDir.exists()) {
-      githubDir.mkdir()
-    }
-
-    if (!workflowsDir.exists()) {
-      workflowsDir.mkdir()
-    }
-
-    workflowsDir
+  private val ciYmlFile: Def.Initialize[Task[FileRef]] = Def task {
+    implicit val conv: xsbti.FileConverter = fileConverter.value
+    toFileRef(baseDirectory.value / ".github" / "workflows" / "ci.yml")
   }
 
-  private val ciYmlFile = Def task {
-    workflowsDirTask.value / "ci.yml"
+  private val cleanYmlFile: Def.Initialize[Task[FileRef]] = Def task {
+    implicit val conv: xsbti.FileConverter = fileConverter.value
+    toFileRef(baseDirectory.value / ".github" / "workflows" / "clean.yml")
   }
 
-  private val cleanYmlFile = Def task {
-    workflowsDirTask.value / "clean.yml"
-  }
+  private implicit val fileRefJsonFormat: sjsonnew.JsonFormat[FileRef] =
+    PluginCompat.fileRefJsonFormat
 
   override def projectSettings = Seq(
     githubWorkflowArtifactUpload := publishArtifact.value,
@@ -968,13 +958,14 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}
     },
     githubWorkflowGenerate / aggregate := false,
     githubWorkflowCheck / aggregate := false,
-    githubWorkflowGenerate := {
+    githubWorkflowGenerate := Def.uncached {
       val ciContents = generateCiContents.value
       val includeClean = githubWorkflowIncludeClean.value
       val cleanContents = readCleanContents.value
 
-      val ciYml = ciYmlFile.value
-      val cleanYml = cleanYmlFile.value
+      implicit val conv: xsbti.FileConverter = fileConverter.value
+      val ciYml = toFile(ciYmlFile.value)
+      val cleanYml = toFile(cleanYmlFile.value)
 
       IO.write(ciYml, ciContents)
 
@@ -986,8 +977,9 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}
       val includeClean = githubWorkflowIncludeClean.value
       val expectedCleanContents = readCleanContents.value
 
-      val ciYml = ciYmlFile.value
-      val cleanYml = cleanYmlFile.value
+      implicit val conv: xsbti.FileConverter = fileConverter.value
+      val ciYml = toFile(ciYmlFile.value)
+      val cleanYml = toFile(cleanYmlFile.value)
 
       val log = state.value.log
 

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/GitHubActionsPlugin.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/GitHubActionsPlugin.scala
@@ -20,7 +20,7 @@ import org.yaml.snakeyaml.Yaml
 import sbt._
 import sbt.io.Using
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import Keys._
 
@@ -33,7 +33,7 @@ object GitHubActionsPlugin extends AutoPlugin {
 
   import autoImport._
 
-  private[this] def recursivelyConvert(a: Any): Any = a match {
+  private def recursivelyConvert(a: Any): Any = a match {
     case map: java.util.Map[_, _] =>
       map.asScala.toMap map { case (k, v) => k -> recursivelyConvert(v) }
 

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/WorkflowStep.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/WorkflowStep.scala
@@ -32,7 +32,7 @@ sealed abstract class WorkflowStep extends Product with Serializable {
   def withContinueOnError(continueOnError: Boolean): WorkflowStep
 
   def updatedEnv(name: String, value: String): WorkflowStep
-  def concatEnv(env: TraversableOnce[(String, String)]): WorkflowStep
+  def concatEnv(env: Seq[(String, String)]): WorkflowStep
 }
 
 object WorkflowStep {
@@ -132,9 +132,9 @@ object WorkflowStep {
     def withWorkingDirectory(workingDirectory: Option[String]): Run
 
     def updatedEnv(name: String, value: String): Run
-    def concatEnv(env: TraversableOnce[(String, String)]): Run
+    def concatEnv(env: Seq[(String, String)]): Run
     def updatedParams(name: String, value: String): Run
-    def concatParams(params: TraversableOnce[(String, String)]): Run
+    def concatParams(params: Seq[(String, String)]): Run
   }
 
   object Run {
@@ -206,9 +206,9 @@ object WorkflowStep {
       def withWorkingDirectory(workingDirectory: Option[String]) = copy(workingDirectory = workingDirectory)
 
       def updatedEnv(name: String, value: String) = copy(env = this.env.updated(name, value))
-      def concatEnv(env: TraversableOnce[(String, String)]) = copy(env = this.env ++ env)
+      def concatEnv(env: Seq[(String, String)]) = copy(env = this.env ++ env)
       def updatedParams(name: String, value: String) = copy(params = this.params.updated(name, value))
-      def concatParams(params: TraversableOnce[(String, String)]) = copy(params = this.params ++ params)
+      def concatParams(params: Seq[(String, String)]) = copy(params = this.params ++ params)
       // scalafmt: { maxColumn = 96 }
     }
   }
@@ -223,9 +223,9 @@ object WorkflowStep {
     def withPreamble(preamble: Boolean): Sbt
 
     def updatedEnv(name: String, value: String): Sbt
-    def concatEnv(env: TraversableOnce[(String, String)]): Sbt
+    def concatEnv(env: Seq[(String, String)]): Sbt
     def updatedParams(name: String, value: String): Sbt
-    def concatParams(params: TraversableOnce[(String, String)]): Sbt
+    def concatParams(params: Seq[(String, String)]): Sbt
   }
 
   object Sbt {
@@ -279,9 +279,9 @@ object WorkflowStep {
       def withPreamble(preamble: Boolean) = copy(preamble = preamble)
 
       def updatedEnv(name: String, value: String) = copy(env = this.env.updated(name, value))
-      def concatEnv(env: TraversableOnce[(String, String)]) = copy(env = this.env ++ env)
+      def concatEnv(env: Seq[(String, String)]) = copy(env = this.env ++ env)
       def updatedParams(name: String, value: String) = copy(params = params.updated(name, value))
-      def concatParams(params: TraversableOnce[(String, String)]) = copy(params = this.params ++ params)
+      def concatParams(params: Seq[(String, String)]) = copy(params = this.params ++ params)
       // scalafmt: { maxColumn = 96 }
     }
   }
@@ -294,9 +294,9 @@ object WorkflowStep {
     def withParams(params: Map[String, String]): Use
 
     def updatedEnv(name: String, value: String): Use
-    def concatEnv(env: TraversableOnce[(String, String)]): Use
+    def concatEnv(env: Seq[(String, String)]): Use
     def updatedParams(name: String, value: String): Use
-    def concatParams(params: TraversableOnce[(String, String)]): Use
+    def concatParams(params: Seq[(String, String)]): Use
   }
 
   object Use {
@@ -356,9 +356,9 @@ object WorkflowStep {
       def withParams(params: Map[String, String]) = copy(params = params)
 
       def updatedEnv(name: String, value: String) = copy(env = this.env.updated(name, value))
-      def concatEnv(env: TraversableOnce[(String, String)]) = copy(env = this.env ++ env)
+      def concatEnv(env: Seq[(String, String)]) = copy(env = this.env ++ env)
       def updatedParams(name: String, value: String) = copy(params = params.updated(name, value))
-      def concatParams(params: TraversableOnce[(String, String)]) = copy(params = this.params ++ params)
+      def concatParams(params: Seq[(String, String)]) = copy(params = this.params ++ params)
       // scalafmt: { maxColumn = 96 }
     }
   }

--- a/github/build.sbt
+++ b/github/build.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.13.2")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.22.0")
 addSbtPlugin("com.github.sbt" % "sbt-git" % "2.1.0")

--- a/github/src/main/scala/org/typelevel/sbt/TypelevelGitHubPlugin.scala
+++ b/github/src/main/scala/org/typelevel/sbt/TypelevelGitHubPlugin.scala
@@ -72,32 +72,33 @@ object TypelevelGitHubPlugin extends AutoPlugin {
     }
   )
 
-  override def projectSettings: Seq[Setting[_]] = Seq(
-    Compile / doc / scalacOptions ++= {
-      val tagOrHash =
-        GitHelper.getTagOrHash(git.gitCurrentTags.value, git.gitHeadCommit.value)
-      val userRepo = gitHubUserRepo.value
-      val infoOpt = scmInfo.value
+  private val sourceUrlOptions = Def.task {
+    val tagOrHash =
+      GitHelper.getTagOrHash(git.gitCurrentTags.value, git.gitHeadCommit.value)
+    val userRepo = gitHubUserRepo.value
+    val infoOpt = scmInfo.value
 
-      tagOrHash.toSeq flatMap { vh =>
-        scalaVersion.value match {
-          case V(V(3, _, _, _)) =>
-            userRepo.toSeq flatMap {
-              case (user, repo) =>
-                Seq(s"-source-links:github://${user}/${repo}", "-revision", vh)
-            }
-          case V(V(2, minor, patch, _)) =>
-            infoOpt.toSeq flatMap { info =>
-              val path =
-                // see https://github.com/scala/bug/issues/12867#issuecomment-1718481858
-                if (minor > 13 || minor == 13 && patch.forall(_ >= 12))
-                  s"${info.browseUrl}/blob/${vh}/€{FILE_PATH}.scala"
-                else s"${info.browseUrl}/blob/${vh}€{FILE_PATH}.scala"
-              Seq("-doc-source-url", path)
-            }
-        }
+    tagOrHash.toSeq flatMap { vh =>
+      scalaVersion.value match {
+        case V(V(3, _, _, _)) =>
+          userRepo.toSeq flatMap {
+            case (user, repo) =>
+              Seq(s"-source-links:github://${user}/${repo}", "-revision", vh)
+          }
+        case V(V(2, minor, patch, _)) =>
+          infoOpt.toSeq flatMap { info =>
+            val path =
+              // see https://github.com/scala/bug/issues/12867#issuecomment-1718481858
+              if (minor > 13 || minor == 13 && patch.forall(_ >= 12))
+                s"${info.browseUrl}/blob/${vh}/€{FILE_PATH}.scala"
+              else s"${info.browseUrl}/blob/${vh}€{FILE_PATH}.scala"
+            Seq("-doc-source-url", path)
+          }
       }
     }
+  }
+  override def projectSettings: Seq[Setting[?]] = Seq(
+    Compile / doc / scalacOptions ++= sourceUrlOptions.value
   )
 
   private def gitHubScmInfo(user: String, repo: String) =

--- a/github/src/main/scala/org/typelevel/sbt/TypelevelScalaJSGitHubPlugin.scala
+++ b/github/src/main/scala/org/typelevel/sbt/TypelevelScalaJSGitHubPlugin.scala
@@ -30,26 +30,27 @@ object TypelevelScalaJSGitHubPlugin extends AutoPlugin {
   import TypelevelKernelPlugin.autoImport._
   import ScalaJSPlugin.autoImport._
 
-  override def projectSettings = Seq(
-    scalacOptions ++= {
-      val flag = if (tlIsScala3.value) "-scalajs-mapSourceURI:" else "-P:scalajs:mapSourceURI:"
+  private val sourceMapOptions = Def.task {
+    val flag = if (tlIsScala3.value) "-scalajs-mapSourceURI:" else "-P:scalajs:mapSourceURI:"
 
-      val tagOrHash =
-        GitHelper
-          .getTagOrHash(git.gitCurrentTags.value, git.gitHeadCommit.value)
-          // Don't include the flag if there are uncommitted changes, since the tag or hash would be inaccurate
-          .filterNot(_ => git.gitUncommittedChanges.value)
+    val tagOrHash =
+      GitHelper
+        .getTagOrHash(git.gitCurrentTags.value, git.gitHeadCommit.value)
+        // Don't include the flag if there are uncommitted changes, since the tag or hash would be inaccurate
+        .filterNot(_ => git.gitUncommittedChanges.value)
 
-      val l = (LocalRootProject / baseDirectory).value.toURI.toString
+    val l = (LocalRootProject / baseDirectory).value.toURI.toString
 
-      tagOrHash.flatMap { v =>
-        scmInfo.value.map { info =>
-          val g =
-            s"${info.browseUrl.toString.replace("github.com", "raw.githubusercontent.com")}/$v/"
-          s"$flag$l->$g"
-        }
+    tagOrHash.flatMap { v =>
+      scmInfo.value.map { info =>
+        val g =
+          s"${info.browseUrl.toString.replace("github.com", "raw.githubusercontent.com")}/$v/"
+        s"$flag$l->$g"
       }
-    },
+    }
+  }
+  override def projectSettings = Seq(
+    scalacOptions ++= sourceMapOptions.value,
     scalaJSLinkerConfig := {
       scalaJSLinkerConfig.value.withBatchMode(sys.env.get("GITHUB_ACTIONS").contains("true"))
     }

--- a/kernel/build.sbt
+++ b/kernel/build.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0")

--- a/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
+++ b/kernel/src/main/scala/org/typelevel/sbt/TypelevelKernelPlugin.scala
@@ -21,6 +21,7 @@ import org.typelevel.sbt.kernel.V
 import sbt.Keys._
 import sbt._
 import sbt.plugins.JvmPlugin
+import sbtcompat.PluginCompat._
 
 import scala.annotation.nowarn
 
@@ -50,7 +51,7 @@ object TypelevelKernelPlugin extends AutoPlugin {
       "0.6.1")
     def tlReplaceCommandAlias(name: String, contents: String): Seq[Setting[State => State]] =
       Seq(GlobalScope / onLoad ~= { (f: State => State) =>
-        f andThen { s: State =>
+        f andThen { (s: State) =>
           BasicCommands.addAlias(BasicCommands.removeAlias(s, name), name, contents)
         }
       })
@@ -84,7 +85,10 @@ object TypelevelKernelPlugin extends AutoPlugin {
   @nowarn("cat=deprecation")
   override def projectSettings = Seq(
     ivyConfigurations += CompileTime,
-    Compile / unmanagedClasspath ++= update.value.select(configurationFilter(CompileTime.name))
+    Compile / unmanagedClasspath ++= Def.uncached {
+      implicit val conv: xsbti.FileConverter = fileConverter.value
+      toAttributedFiles(update.value.select(configurationFilter(CompileTime.name)))
+    }
   )
 
   private[sbt] def mkCommand(commands: List[String]): String = commands.mkString("; ", "; ", "")
@@ -112,7 +116,7 @@ object TypelevelKernelPlugin extends AutoPlugin {
     previousReleases.value.headOption.map(_.toString)
   }
 
-  private[this] lazy val previousReleases: Def.Initialize[List[V]] = Def.setting {
+  private lazy val previousReleases: Def.Initialize[List[V]] = Def.setting {
     val currentVersion = V(version.value).map(_.copy(prerelease = None))
     GitHelper.previousReleases(fromHead = true, strict = false).filter { v =>
       currentVersion.forall(v.copy(prerelease = None) <= _)

--- a/mergify/build.sbt
+++ b/mergify/build.sbt
@@ -1,2 +1,2 @@
 libraryDependencies += "io.circe" %% "circe-yaml" % "0.14.2"
-addSbtPlugin("org.portable-scala" % "sbt-crossproject" % "1.3.2")
+addSbtPlugin("org.portable-scala" % "sbt-crossproject" % "1.4.0")

--- a/mergify/src/main/scala/org/typelevel/sbt/mergify/MergifyAction.scala
+++ b/mergify/src/main/scala/org/typelevel/sbt/mergify/MergifyAction.scala
@@ -81,43 +81,43 @@ object MergifyAction {
       new RequestReviews(users, teams, usersFromTeams, randomCount) {}
 
     def withUsers(user: String, users: String*): RequestReviews =
-      copy(users = Unweighted(NonEmptyList.of(user, users: _*)).some)
+      copy(users = Unweighted(NonEmptyList.of(user, users*)).some)
 
     def withUsers(user: (String, Int), users: (String, Int)*): RequestReviews =
-      copy(users = Weighted(NonEmptyList.of(user, users: _*)).some)
+      copy(users = Weighted(NonEmptyList.of(user, users*)).some)
 
     def withTeams(team: String, teams: String*): RequestReviews =
-      copy(teams = Unweighted(NonEmptyList.of(team, teams: _*)).some)
+      copy(teams = Unweighted(NonEmptyList.of(team, teams*)).some)
 
     def withTeams(team: (String, Int), teams: (String, Int)*): RequestReviews =
-      copy(teams = Weighted(NonEmptyList.of(team, teams: _*)).some)
+      copy(teams = Weighted(NonEmptyList.of(team, teams*)).some)
 
     def withUsersFromTeams(team: String, teams: String*): RequestReviews =
-      copy(usersFromTeams = Unweighted(NonEmptyList.of(team, teams: _*)).some)
+      copy(usersFromTeams = Unweighted(NonEmptyList.of(team, teams*)).some)
 
     def withUsersFromTeams(team: (String, Int), teams: (String, Int)*): RequestReviews =
-      copy(usersFromTeams = Weighted(NonEmptyList.of(team, teams: _*)).some)
+      copy(usersFromTeams = Weighted(NonEmptyList.of(team, teams*)).some)
 
     def withRandomCount(count: Int): RequestReviews =
       copy(randomCount = Option(count))
 
     def withDevelopers(developers: List[Developer]): RequestReviews =
-      copy(users = NonEmptyList.fromList(developers.map(_.id)).map(Unweighted))
+      copy(users = NonEmptyList.fromList(developers.map(_.id)).map(Unweighted(_)))
   }
 
   object RequestReviews {
     def fromUsers(user: String, users: String*) =
-      new RequestReviews(Unweighted(NonEmptyList.of(user, users: _*)).some, None, None, None)
+      new RequestReviews(Unweighted(NonEmptyList.of(user, users*)).some, None, None, None)
     def fromUsers(user: (String, Int), users: (String, Int)*) =
-      new RequestReviews(Weighted(NonEmptyList.of(user, users: _*)).some, None, None, None)
+      new RequestReviews(Weighted(NonEmptyList.of(user, users*)).some, None, None, None)
     def fromTeams(team: String, teams: String*) =
-      new RequestReviews(None, Unweighted(NonEmptyList.of(team, teams: _*)).some, None, None)
+      new RequestReviews(None, Unweighted(NonEmptyList.of(team, teams*)).some, None, None)
     def fromTeams(team: (String, Int), teams: (String, Int)*) =
-      new RequestReviews(None, Weighted(NonEmptyList.of(team, teams: _*)).some, None, None)
+      new RequestReviews(None, Weighted(NonEmptyList.of(team, teams*)).some, None, None)
     def fromUsersOfTeams(team: String, teams: String*) =
-      new RequestReviews(None, None, Unweighted(NonEmptyList.of(team, teams: _*)).some, None)
+      new RequestReviews(None, None, Unweighted(NonEmptyList.of(team, teams*)).some, None)
     def fromUsersOfTeams(team: (String, Int), teams: (String, Int)*) =
-      new RequestReviews(None, None, Weighted(NonEmptyList.of(team, teams: _*)).some, None)
+      new RequestReviews(None, None, Weighted(NonEmptyList.of(team, teams*)).some, None)
 
     def apply(developers: List[Developer]) =
       new RequestReviews(
@@ -161,6 +161,6 @@ object MergifyAction {
       Encoder[JsonObject].contramap(_ => JsonObject.empty)
   }
 
-  @nowarn("cat=unused")
-  private[this] object Dummy extends MergifyAction
+  @nowarn()
+  private object Dummy extends MergifyAction
 }

--- a/mergify/src/main/scala/org/typelevel/sbt/mergify/MergifyCondition.scala
+++ b/mergify/src/main/scala/org/typelevel/sbt/mergify/MergifyCondition.scala
@@ -46,6 +46,6 @@ object MergifyCondition {
     implicit def encoder: Encoder[Or] = Encoder.forProduct1("or")(_.conditions)
   }
 
-  @nowarn("cat=unused")
-  private[this] final object Dummy extends MergifyCondition // break exhaustivity checking
+  @nowarn()
+  private object Dummy extends MergifyCondition // break exhaustivity checking
 }

--- a/mergify/src/main/scala/org/typelevel/sbt/mergify/MergifyPlugin.scala
+++ b/mergify/src/main/scala/org/typelevel/sbt/mergify/MergifyPlugin.scala
@@ -62,7 +62,7 @@ object MergifyPlugin extends AutoPlugin {
   import autoImport._
   import GenerativePlugin.autoImport._
 
-  override def buildSettings: Seq[Setting[_]] = Seq(
+  override def buildSettings: Seq[Setting[?]] = Seq(
     mergifyStewardConfig := Some(MergifyStewardConfig()),
     mergifyRequiredJobs := Seq("build"),
     mergifyLabelPaths := internallyCalculatedMergifyLabelPaths.value,
@@ -109,7 +109,7 @@ object MergifyPlugin extends AutoPlugin {
     }
   )
 
-  override def projectSettings: Seq[Setting[_]] = Seq(
+  override def projectSettings: Seq[Setting[?]] = Seq(
     mergifyGenerate / aggregate := false,
     mergifyCheck / aggregate := false,
     githubWorkflowGenerate := githubWorkflowGenerate

--- a/mima/src/main/scala/org/typelevel/sbt/TypelevelMimaPlugin.scala
+++ b/mima/src/main/scala/org/typelevel/sbt/TypelevelMimaPlugin.scala
@@ -40,7 +40,7 @@ object TypelevelMimaPlugin extends AutoPlugin {
 
   import autoImport._
 
-  override def buildSettings = Seq[Setting[_]](
+  override def buildSettings = Seq[Setting[?]](
     tlVersionIntroduced := Map.empty,
     tlMimaPreviousVersions := {
       require(
@@ -61,7 +61,7 @@ object TypelevelMimaPlugin extends AutoPlugin {
     }
   )
 
-  override def projectSettings = Seq[Setting[_]](
+  override def projectSettings = Seq[Setting[?]](
     mimaReportBinaryIssues := {
       if (!publishArtifact.value) ()
       else mimaReportBinaryIssues.value

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -17,8 +17,9 @@ val modules = List(
   "versioning"
 )
 
-Compile / unmanagedSourceDirectories ++= modules.map { module =>
-  baseDirectory.value.getParentFile / module / "src" / "main" / "scala"
+Compile / unmanagedSourceDirectories ++= modules.flatMap { module =>
+  val moduleDir = baseDirectory.value.getParentFile / module / "src" / "main"
+  Seq(moduleDir / "scala", moduleDir / "scala-2.12")
 }
 
 Compile / unmanagedResourceDirectories ++= modules.map { module =>

--- a/project/kernel.sbt
+++ b/project/kernel.sbt
@@ -1,0 +1,1 @@
+../kernel/build.sbt

--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -1,1 +1,2 @@
+addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.7")

--- a/scalafix/src/main/scala-2.12/org/typelevel/sbt/ScalafixProjectMacros.scala
+++ b/scalafix/src/main/scala-2.12/org/typelevel/sbt/ScalafixProjectMacros.scala
@@ -17,7 +17,12 @@
 package org.typelevel.sbt
 
 import scala.annotation.tailrec
+import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
+
+trait ScalafixProjectMacros {
+  def tlScalafixProject: ScalafixProject = macro ScalafixProjectMacros.scalafixProjectImpl
+}
 
 private[sbt] object ScalafixProjectMacros {
 

--- a/scalafix/src/main/scala-3/org/typelevel/sbt/ScalafixProjectMacros.scala
+++ b/scalafix/src/main/scala-3/org/typelevel/sbt/ScalafixProjectMacros.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.typelevel.sbt
+import scala.quoted.*
+import scala.annotation.tailrec
+
+
+private[sbt] trait ScalafixProjectMacros {
+  // Adapted from sbt.std.KeyMacro.projectImpl
+  inline def scalafixProject: ScalafixProject = ${ ScalafixProjectMacros.scalafixProjectImpl }
+}
+
+private[sbt] object ScalafixProjectMacros {
+  def scalafixProjectImpl(using Quotes): Expr[ScalafixProject] =
+    val name = definingValName
+    '{ ScalafixProject($name) }
+
+  private def definingValName(using q: Quotes): Expr[String] =
+    val term = enclosingTerm
+    if term.isValDef then Expr(term.name)
+    else q.reflect.report.errorAndAbort(errorMsg)
+
+  private def enclosingTerm(using qctx: Quotes) =
+    import qctx.reflect.*
+    @tailrec
+    def enclosingTerm0(sym: Symbol): Symbol =
+      sym match
+        case sym if sym.flags.is(Flags.Macro)     => enclosingTerm0(sym.owner)
+        case sym if sym.flags.is(Flags.Synthetic) => enclosingTerm0(sym.owner)
+        case sym if !sym.isTerm                   => enclosingTerm0(sym.owner)
+        case _                                    => sym
+    enclosingTerm0(Symbol.spliceOwner)
+
+  private def errorMsg: String = "tlScalafixProject must be directly assigned to a val, such as `val x = tlScalafixProject`. Alternatively, you can use `org.typelevel.sbt.ScalafixProject.apply`"
+}

--- a/scalafix/src/main/scala/org/typelevel/sbt/ScalafixProject.scala
+++ b/scalafix/src/main/scala/org/typelevel/sbt/ScalafixProject.scala
@@ -17,6 +17,7 @@
 package org.typelevel.sbt
 
 import sbt._
+import sbtcompat.PluginCompat._
 import scalafix.sbt._
 
 import Keys._
@@ -32,7 +33,8 @@ final class ScalafixProject private (
 
   lazy val componentProjects = Seq(rules, input, output, tests)
 
-  def componentProjectReferences = componentProjects.map(x => x: ProjectReference)
+  def componentProjectReferences =
+    componentProjects.map(x => LocalProject(x.id): ProjectReference)
 
   def in(dir: File): ScalafixProject =
     new ScalafixProject(
@@ -44,21 +46,21 @@ final class ScalafixProject private (
     )
 
   def rulesSettings(ss: Def.SettingsDefinition*): ScalafixProject =
-    rulesConfigure(_.settings(ss: _*))
+    rulesConfigure(_.settings(ss*))
 
   def inputSettings(ss: Def.SettingsDefinition*): ScalafixProject =
-    inputConfigure(_.settings(ss: _*))
+    inputConfigure(_.settings(ss*))
 
   def outputSettings(ss: Def.SettingsDefinition*): ScalafixProject =
-    outputConfigure(_.settings(ss: _*))
+    outputConfigure(_.settings(ss*))
 
   def testsSettings(ss: Def.SettingsDefinition*): ScalafixProject =
-    testsConfigure(_.settings(ss: _*))
+    testsConfigure(_.settings(ss*))
 
   def rulesConfigure(transforms: (Project => Project)*): ScalafixProject =
     new ScalafixProject(
       name,
-      rules.configure(transforms: _*),
+      rules.configure(transforms*),
       input,
       output,
       tests
@@ -68,7 +70,7 @@ final class ScalafixProject private (
     new ScalafixProject(
       name,
       rules,
-      input.configure(transforms: _*),
+      input.configure(transforms*),
       output,
       tests
     )
@@ -78,7 +80,7 @@ final class ScalafixProject private (
       name,
       rules,
       input,
-      output.configure(transforms: _*),
+      output.configure(transforms*),
       tests
     )
 
@@ -88,7 +90,7 @@ final class ScalafixProject private (
       rules,
       input,
       output,
-      tests.configure(transforms: _*)
+      tests.configure(transforms*)
     )
 
 }
@@ -112,13 +114,19 @@ object ScalafixProject {
 
     lazy val tests = Project(s"$name-tests", file(s"$name/tests"))
       .settings(
-        scalafixTestkitOutputSourceDirectories := (output / Compile / unmanagedSourceDirectories).value,
-        scalafixTestkitInputSourceDirectories := (input / Compile / unmanagedSourceDirectories).value,
-        scalafixTestkitInputClasspath := (input / Compile / fullClasspath).value,
-        scalafixTestkitInputScalacOptions := (input / Compile / scalacOptions).value,
-        scalafixTestkitInputScalaVersion := (input / Compile / scalaVersion).value
+        scalafixTestkitOutputSourceDirectories := (LocalProject(
+          output.id) / Compile / unmanagedSourceDirectories).value,
+        scalafixTestkitInputSourceDirectories := (LocalProject(
+          input.id) / Compile / unmanagedSourceDirectories).value,
+        scalafixTestkitInputClasspath := Def.uncached {
+          (LocalProject(input.id) / Compile / fullClasspath).value
+        },
+        scalafixTestkitInputScalacOptions := (LocalProject(
+          input.id) / Compile / scalacOptions).value,
+        scalafixTestkitInputScalaVersion := (LocalProject(
+          input.id) / Compile / scalaVersion).value
       )
-      .dependsOn(rules)
+      .dependsOn(LocalProject(rules.id))
       .enablePlugins(NoPublishPlugin, ScalafixTestkitPlugin)
 
     new ScalafixProject(name, rules, input, output, tests)

--- a/scalafix/src/main/scala/org/typelevel/sbt/TypelevelScalafixPlugin.scala
+++ b/scalafix/src/main/scala/org/typelevel/sbt/TypelevelScalafixPlugin.scala
@@ -19,8 +19,6 @@ package org.typelevel.sbt
 import sbt._
 import scalafix.sbt.ScalafixPlugin
 
-import scala.language.experimental.macros
-
 import Keys._
 import ScalafixPlugin.autoImport._
 
@@ -30,17 +28,15 @@ object TypelevelScalafixPlugin extends AutoPlugin {
 
   override def trigger = allRequirements
 
-  object autoImport {
+  object autoImport extends ScalafixProjectMacros {
     val tlTypelevelScalafixVersion = settingKey[Option[String]](
       "The version of typelevel-scalafix to add to the scalafix dependency classpath, or None to omit the dependency entirely."
     )
-
-    def tlScalafixProject: ScalafixProject = macro ScalafixProjectMacros.scalafixProjectImpl
   }
 
   import autoImport._
 
-  override def buildSettings = Seq[Setting[_]](
+  override def buildSettings = Seq[Setting[?]](
     semanticdbEnabled := true,
     semanticdbVersion := scalafixSemanticdb.revision,
     SettingKey[Boolean]("tlCiScalafixCheck") := true,

--- a/settings/build.sbt
+++ b/settings/build.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("com.github.sbt" % "sbt-git" % "2.1.0")
-addSbtPlugin("org.portable-scala" % "sbt-crossproject" % "1.3.2")
+addSbtPlugin("org.portable-scala" % "sbt-crossproject" % "1.4.0")

--- a/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
+++ b/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
@@ -19,6 +19,7 @@ package org.typelevel.sbt
 import com.github.sbt.git.GitPlugin
 import org.typelevel.sbt.kernel.V
 import sbt._
+import sbtcompat.PluginCompat._
 import sbtcrossproject.CrossPlugin.autoImport._
 
 import java.io.File
@@ -61,7 +62,7 @@ object TypelevelSettingsPlugin extends AutoPlugin {
           Seq(
             compilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1"),
             compilerPlugin(
-              "org.typelevel" % "kind-projector" % "0.13.4" cross CrossVersion.full)
+              ("org.typelevel" % "kind-projector" % "0.13.4").cross(CrossVersion.full))
           )
 
       val scalacCompat =
@@ -359,11 +360,12 @@ object TypelevelSettingsPlugin extends AutoPlugin {
       }
     },
     packageSrc / mappings ++= {
+      implicit val conv: xsbti.FileConverter = fileConverter.value
       val bases = managedSourceDirectories.value
       managedSources.value.map { file =>
         bases
           .map(b => file.relativeTo(b))
-          .collectFirst { case Some(relative) => file -> relative.getPath }
+          .collectFirst { case Some(relative) => toFileRef(file) -> relative.getPath }
           .getOrElse {
             throw new RuntimeException(
               s"""|Expected managed sources in:
@@ -399,7 +401,7 @@ object TypelevelSettingsPlugin extends AutoPlugin {
 
   private val javaApiMappings = {
     // scaladoc doesn't support this automatically before 2.13
-    doc / apiMappings := {
+    doc / apiMappings := Def.uncached {
       val old = (doc / apiMappings).value
 
       val baseUrl = tlJdkRelease.value.getOrElse(javaMajorVersion) match {
@@ -408,21 +410,22 @@ object TypelevelSettingsPlugin extends AutoPlugin {
       }
 
       val runtimeMXBean = ManagementFactory.getRuntimeMXBean
+      implicit val conv: xsbti.FileConverter = fileConverter.value
       val oldSchool = Try(
         if (runtimeMXBean.isBootClassPathSupported)
           runtimeMXBean
             .getBootClassPath
             .split(File.pathSeparatorChar)
-            .map(file(_) -> baseUrl)
+            .map(x => toFileRef(file(x)) -> baseUrl)
             .toMap
         else Map.empty
       ).getOrElse(Map.empty)
-      val newSchool = Map(file("/modules/java.base") -> baseUrl)
+      val newSchool = Map(toFileRef(file("/modules/java.base")) -> baseUrl)
       // Latest one wins.  We are providing a fallback.
       oldSchool ++ newSchool ++ old
     }
   }
 
-  @nowarn("cat=unused")
-  private[this] def unused(): Unit = ()
+  @nowarn()
+  private def unused(): Unit = ()
 }

--- a/versioning/src/main/scala/org/typelevel/sbt/TypelevelVersioningPlugin.scala
+++ b/versioning/src/main/scala/org/typelevel/sbt/TypelevelVersioningPlugin.scala
@@ -22,11 +22,9 @@ import org.typelevel.sbt.TypelevelKernelPlugin._
 import org.typelevel.sbt.kernel.GitHelper
 import org.typelevel.sbt.kernel.V
 import sbt._
-import sbt._
 
 import scala.util.Try
 
-import Keys._
 import Keys._
 
 object TypelevelVersioningPlugin extends AutoPlugin {
@@ -50,7 +48,7 @@ object TypelevelVersioningPlugin extends AutoPlugin {
 
   import autoImport._
 
-  override def buildSettings: Seq[Setting[_]] = Seq(
+  override def buildSettings: Seq[Setting[?]] = Seq(
     versionScheme := Some("early-semver"),
     tlUntaggedAreSnapshots := true,
     isSnapshot := {


### PR DESCRIPTION
This is a work-in-progress for cross building all modules to SBT 2.0. See #899 .

## Module checklist
- [X] `kernel`
- [X] `noPublish`
- [x] `settings`: Requires a sbt-crossproject upgrade
- [x] `github`: Requires a scala-js upgrade
- [X] `githubActions`
- [x]  `mergify`: Requires a sbt-crossproject upgrade
- [X] `versioning`
- [X]  `mima`
- [X] `sonatype`
- [X]  `scalafix`: Has macros
- [ ] `ciSigning`: Requires sbt-gpg. See #907 .
- [X] `sonatypeCiRelease`
- [X] `ci`: Has macros
- [ ] `core`: Depends on other plugins
- [ ] `ciRelease`: Depends on other plugins
- [ ] `site`: Requires laika 
- [X] `unidoc`
