### PR TITLE
Replace `sbt-crossproject` with `sbt-projectmatrix`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, macos-latest, windows-2022]
-        scala: [2.12]
+        scala: [2_12]
         java:
           - temurin@8
           - temurin@11
@@ -198,26 +198,26 @@ jobs:
       - name: Check headers and formatting
         if: matrix.java == 'temurin@8' && matrix.os == 'ubuntu-22.04'
         shell: bash
-        run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' headerCheckAll scalafmtCheckAll 'project /' scalafmtSbtCheck
+        run: sbt 'project ${{ matrix.project }}${{ matrix.scala }}' headerCheckAll scalafmtCheckAll 'project /' scalafmtSbtCheck
 
       - name: Check scalafix lints
         if: matrix.java == 'temurin@8' && matrix.os == 'ubuntu-22.04'
         shell: bash
-        run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' 'scalafixAll --check'
+        run: sbt 'project ${{ matrix.project }}${{ matrix.scala }}' 'scalafixAll --check'
 
       - name: Test
         shell: bash
-        run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' test
+        run: sbt 'project ${{ matrix.project }}${{ matrix.scala }}' test
 
       - name: Check binary compatibility
         if: matrix.java == 'temurin@8' && matrix.os == 'ubuntu-22.04'
         shell: bash
-        run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' mimaReportBinaryIssues
+        run: sbt 'project ${{ matrix.project }}${{ matrix.scala }}' mimaReportBinaryIssues
 
       - name: Generate API documentation
         if: matrix.java == 'temurin@8' && matrix.os == 'ubuntu-22.04'
         shell: bash
-        run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' doc
+        run: sbt 'project ${{ matrix.project }}${{ matrix.scala }}' doc
 
       - shell: bash
         working-directory: project
@@ -358,12 +358,12 @@ jobs:
         if: matrix.java == 'semeru@17' && steps.setup-java-semeru-17.outputs.cache-hit == 'false'
         run: sbt +update
 
-      - name: Download target directories (2.12, sbt-typelevelJVM)
+      - name: Download target directories (2_12, sbt-typelevelJVM)
         uses: actions/download-artifact@v6
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12-sbt-typelevelJVM
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2_12-sbt-typelevelJVM
 
-      - name: Inflate target directories (2.12, sbt-typelevelJVM)
+      - name: Inflate target directories (2_12, sbt-typelevelJVM)
         run: |
           tar xf targets.tar
           rm targets.tar
@@ -507,7 +507,7 @@ jobs:
       - name: Submit Dependencies
         uses: scalacenter/sbt-dependency-submission@v2
         with:
-          modules-ignore: sbt-typeleveljvm_2.12 docs_2.12 sbt-typelevelnative_2.12 sbt-typeleveljs_2.12
+          modules-ignore: docs_2.12 sbt-typeleveljvm2_12_2.12 sbt-typelevelnative2_12_2.12 sbt-typeleveljs2_12_2.12
           configs-ignore: test scala-tool scala-doc-tool test-internal
 
   validate-steward:

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,7 @@ import org.typelevel.sbt.gha.{PermissionScope, PermissionValue, Permissions}
 import com.typesafe.tools.mima.core._
 
 ThisBuild / tlBaseVersion := "0.8"
+ThisBuild / version := "1.1.1"
 ThisBuild / crossScalaVersions := Seq("2.12.21")
 ThisBuild / developers ++= List(
   tlGitHubDev("armanbilge", "Arman Bilge"),
@@ -101,7 +102,10 @@ ThisBuild / githubWorkflowPermissions := Some(Permissions.Specify.defaultPermiss
 
 val MunitVersion = "1.3.5"
 
-lazy val `sbt-typelevel` = tlCrossRootProject.aggregate(
+import org.typelevel.sbt.CrossRootProject
+
+lazy val `sbt-typelevel` = CrossRootProject("sbt-typelevel", Seq("2.12")).aggregate(
+  scalaVersion = "2.12",
   kernel,
   noPublish,
   settings,

--- a/ci/build.sbt
+++ b/ci/build.sbt
@@ -1,2 +1,1 @@
-libraryDependencies += "io.circe" %% "circe-yaml" % "0.14.2"
 addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.11.0")

--- a/ci/src/main/scala/org/typelevel/sbt/CrossRootProject.scala
+++ b/ci/src/main/scala/org/typelevel/sbt/CrossRootProject.scala
@@ -18,6 +18,7 @@ package org.typelevel.sbt
 
 import org.typelevel.sbt.gha.GenerativePlugin.autoImport._
 import sbt._
+import sbt.internal.ProjectMatrix
 
 import Keys._
 
@@ -27,29 +28,34 @@ import Keys._
  */
 final class CrossRootProject private (
     val all: Project,
-    val jvm: Project,
-    val js: Project,
-    val native: Project
+    val jvm: Map[String, Project],
+    val js: Map[String, Project],
+    val native: Map[String, Project]
 ) extends CompositeProject {
 
-  override def componentProjects: Seq[Project] = Seq(all, jvm, js, native)
+  override def componentProjects: Seq[Project] =
+    Seq(all) ++
+      jvm.values ++
+      js.values ++
+      native.values
 
   def settings(ss: Def.SettingsDefinition*): CrossRootProject =
     new CrossRootProject(
       all.settings(ss: _*),
-      jvm.settings(ss: _*),
-      js.settings(ss: _*),
-      native.settings(ss: _*)
+      mapProject(jvm)(_.settings(ss: _*)),
+      mapProject(js)(_.settings(ss: _*)),
+      mapProject(native)(_.settings(ss: _*))
     )
 
   def configure(transforms: (Project => Project)*): CrossRootProject =
     new CrossRootProject(
       all.configure(transforms: _*),
-      jvm.configure(transforms: _*),
-      js.configure(transforms: _*),
-      native.configure(transforms: _*)
+      mapProject(jvm)(_.configure(transforms: _*)),
+      mapProject(js)(_.configure(transforms: _*)),
+      mapProject(native)(_.configure(transforms: _*))
     )
 
+  // TODO: Zainab - See Laika and feral builds to understand how "all" is used.
   def configureRoot(transforms: (Project => Project)*): CrossRootProject =
     new CrossRootProject(
       all.configure(transforms: _*),
@@ -61,7 +67,7 @@ final class CrossRootProject private (
   def configureJVM(transforms: (Project => Project)*): CrossRootProject =
     new CrossRootProject(
       all,
-      jvm.configure(transforms: _*),
+      mapProject(jvm)(_.configure(transforms: _*)),
       js,
       native
     )
@@ -70,7 +76,7 @@ final class CrossRootProject private (
     new CrossRootProject(
       all,
       jvm,
-      js.configure(transforms: _*),
+      mapProject(js)(_.configure(transforms: _*)),
       native
     )
 
@@ -79,67 +85,132 @@ final class CrossRootProject private (
       all,
       jvm,
       js,
-      native.configure(transforms: _*)
+      mapProject(native)(_.configure(transforms: _*))
     )
 
   def enablePlugins(ns: Plugins*): CrossRootProject =
     new CrossRootProject(
       all.enablePlugins(ns: _*),
-      jvm.enablePlugins(ns: _*),
-      js.enablePlugins(ns: _*),
-      native.enablePlugins(ns: _*)
+      mapProject(jvm)(_.enablePlugins(ns: _*)),
+      mapProject(js)(_.enablePlugins(ns: _*)),
+      mapProject(native)(_.enablePlugins(ns: _*))
     )
 
   def disablePlugins(ps: AutoPlugin*): CrossRootProject =
     new CrossRootProject(
       all.disablePlugins(ps: _*),
-      jvm.disablePlugins(ps: _*),
-      js.disablePlugins(ps: _*),
-      native.disablePlugins(ps: _*)
+      mapProject(jvm)(_.disablePlugins(ps: _*)),
+      mapProject(js)(_.disablePlugins(ps: _*)),
+      mapProject(native)(_.disablePlugins(ps: _*))
     )
 
-  def aggregate(projects: CompositeProject*): CrossRootProject =
-    aggregateImpl(projects.flatMap(_.componentProjects): _*)
+  def aggregate(projects: ProjectMatrix*): CrossRootProject = {
+    aggregateImpl(projects)
+  }
 
-  private def aggregateImpl(projects: Project*): CrossRootProject = {
+  def aggregate(scalaVersion: String, projects: Project*): CrossRootProject = {
+    val componentProjects = projects.flatMap(_.componentProjects)
     val jsProjects =
-      projects.filter(_.plugins.toString.contains("org.scalajs.sbtplugin.ScalaJSPlugin"))
-
+      componentProjects.filter(
+        _.plugins.toString.contains("org.scalajs.sbtplugin.ScalaJSPlugin"))
     val nativeProjects =
-      projects.filter(
+      componentProjects.filter(
         _.plugins.toString.contains("scala.scalanative.sbtplugin.ScalaNativePlugin"))
-
-    val jvmProjects = projects.diff(jsProjects).diff(nativeProjects)
-
-    new CrossRootProject(
-      all.aggregate(projects.map(_.project): _*),
-      if (jvmProjects.nonEmpty)
-        jvm.aggregate(jvmProjects.map(_.project): _*).enablePlugins(TypelevelCiJVMPlugin)
-      else jvm,
-      if (jsProjects.nonEmpty)
-        js.aggregate(jsProjects.map(_.project): _*).enablePlugins(TypelevelCiJSPlugin)
-      else js,
-      if (nativeProjects.nonEmpty)
-        native
-          .aggregate(nativeProjects.map(_.project): _*)
-          .enablePlugins(TypelevelCiNativePlugin)
-      else native
+    val jvmProjects =
+      projects.diff(jsProjects).diff(nativeProjects)
+    aggregateForScalaVersion(
+      scalaVersion,
+      jvmProjects,
+      jsProjects,
+      nativeProjects
     )
   }
 
+  private def mapProject(kvs: Map[String, Project])(
+      f: Project => Project): Map[String, Project] =
+    kvs.map { case (k, v) => k -> f(v) }
+
+  private def aggregateImpl(matrices: Seq[ProjectMatrix]): CrossRootProject = {
+
+    def projectsForScalaVersion(scalaVersion: String, axis: VirtualAxis): Seq[Project] = {
+      matrices.flatMap { matrix =>
+        matrix.allProjects().collect {
+          case (project, axes)
+              if axes.contains(axis) &&
+                axes.exists {
+                  case VirtualAxis.ScalaVersionAxis(_, scalaBinaryVersion) =>
+                    scalaBinaryVersion == scalaVersion
+                  case _ => false
+                } =>
+            project
+        }
+      }
+    }
+    val scalaVersions = jvm.keys.toList
+    scalaVersions.foldLeft(this) { (crossRootProj, scalaVersion) =>
+      crossRootProj.aggregateForScalaVersion(
+        scalaVersion,
+        jvmProjects = projectsForScalaVersion(scalaVersion, VirtualAxis.jvm),
+        jsProjects = projectsForScalaVersion(scalaVersion, VirtualAxis.js),
+        nativeProjects = projectsForScalaVersion(scalaVersion, VirtualAxis.native)
+      )
+    }
+  }
+
+  private def aggregateForScalaVersion(
+      scalaVersion: String,
+      jvmProjects: Seq[Project],
+      jsProjects: Seq[Project],
+      nativeProjects: Seq[Project]): CrossRootProject = {
+    val allProjects = jvmProjects ++ jsProjects ++ nativeProjects
+    new CrossRootProject(
+      all.aggregate(allProjects.map(_.project): _*),
+      jvm = addProjects(jvm, scalaVersion, jvmProjects, TypelevelCiJVMPlugin),
+      js = addProjects(js, scalaVersion, jsProjects, TypelevelCiJSPlugin),
+      native = addProjects(native, scalaVersion, nativeProjects, TypelevelCiNativePlugin)
+    )
+  }
+
+  private def addProjects(
+      existingProjects: Map[String, Project],
+      scalaVersion: String,
+      additionalProjects: Seq[Project],
+      plugin: AutoPlugin): Map[String, Project] = {
+    if (additionalProjects.nonEmpty) {
+      existingProjects + (scalaVersion -> existingProjects(scalaVersion)
+        .aggregate(additionalProjects.map(_.project): _*)
+        .enablePlugins(plugin))
+    } else {
+      existingProjects
+    }
+  }
 }
 
 object CrossRootProject {
-  def unapply(rootProject: CrossRootProject): Some[(Project, Project, Project, Project)] =
-    Some((rootProject.all, rootProject.jvm, rootProject.js, rootProject.native))
 
-  def apply(id: String): CrossRootProject = new CrossRootProject(
+  private val defaultScalaVersions: Seq[String] = Seq("2.12", "2.13", "3")
+
+  // TODO: Zainab - Add a field for scala versions into the macro, or extract it from crossScalaVersions if possible.
+  def apply(id: String): CrossRootProject =
+    apply(id, defaultScalaVersions)
+
+  def apply(id: String, scalaVersions: Seq[String]): CrossRootProject = new CrossRootProject(
     Project(id, file("."))
       .settings(crossScalaVersions := Nil, scalaVersion := (ThisBuild / scalaVersion).value),
-    Project(s"${id}JVM", file(".jvm")),
-    Project(s"${id}JS", file(".js")),
-    Project(s"${id}Native", file(".native"))
+    platformProject(id, scalaVersions, "JVM"),
+    platformProject(id, scalaVersions, "JS"),
+    platformProject(id, scalaVersions, "Native")
   ).enablePlugins(NoPublishPlugin, TypelevelCiCrossPlugin)
+
+  private def platformProject(
+      id: String,
+      scalaVersions: Seq[String],
+      platform: String): Map[String, Project] = {
+    scalaVersions.map { version =>
+      val suffix = version.replace(".", "_")
+      version -> Project(s"${id}${platform}$suffix", file(s".${platform.toLowerCase}$suffix"))
+    }.toMap
+  }
 }
 
 /**
@@ -158,7 +229,9 @@ object TypelevelCiCrossPlugin extends AutoPlugin {
   override def requires = TypelevelCiPlugin
 
   override def buildSettings = Seq(
-    githubWorkflowBuildSbtStepPreamble ~= { s"project $${{ matrix.project }}" +: _ },
+    githubWorkflowBuildSbtStepPreamble ~= {
+      s"project $${{ matrix.project }}$${{ matrix.scala }}" +: _
+    },
     githubWorkflowBuildMatrixAdditions += "project" -> Nil,
     githubWorkflowArtifactDownloadExtraKeys += "project"
   )

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.6")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.10.0")
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
-addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.3.7")
+addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.11.0")

--- a/core/src/main/scala/org/typelevel/sbt/TypelevelBspPlugin.scala
+++ b/core/src/main/scala/org/typelevel/sbt/TypelevelBspPlugin.scala
@@ -17,18 +17,18 @@
 package org.typelevel.sbt
 
 import sbt.Keys._
+import sbt.VirtualAxis.PlatformAxis
 import sbt._
-import sbtcrossproject.CrossPlugin
-import sbtcrossproject.CrossPlugin.autoImport._
-import sbtcrossproject.Platform
+import sbtprojectmatrix.ProjectMatrixKeys.virtualAxes
+import sbtprojectmatrix.ProjectMatrixPlugin
 
 object TypelevelBspPlugin extends AutoPlugin {
   override def trigger = allRequirements
-  override def requires: Plugins = CrossPlugin
+  override def requires: Plugins = ProjectMatrixPlugin
 
   object autoImport {
-    lazy val tlBspCrossProjectPlatforms: SettingKey[Set[Platform]] =
-      settingKey[Set[Platform]](
+    lazy val tlBspCrossProjectPlatforms: SettingKey[Set[PlatformAxis]] =
+      settingKey[Set[PlatformAxis]](
         "A set of platforms for which BSP should be enabled (default: not initialized)")
   }
 
@@ -38,20 +38,13 @@ object TypelevelBspPlugin extends AutoPlugin {
     bspEnabled := {
       val oldValue = bspEnabled.value
 
-      // We have to check if `crossProjectCrossType` and `crossProjectPlatform`
-      // are initialized. Otherwise, the `sbt-typelevel` won't load itself.
-      (
-        crossProjectCrossType.?.value,
-        crossProjectPlatform.?.value,
-        tlBspCrossProjectPlatforms.?.value
-      ) match {
-        // `tlBspCrossProjectPlatforms` is set by a user explicitly.
-        case (_, Some(projectPlatform), Some(bspPlatforms)) =>
-          bspPlatforms.contains(projectPlatform)
-        // If `CrossType` is `Pure` then enable BSP for the JVM platform only.
-        case (Some(CrossType.Pure), Some(projectPlatform), None) =>
-          projectPlatform == JVMPlatform
-        // Otherwise simply return the old value.
+      (virtualAxes.?.value, tlBspCrossProjectPlatforms.?.value) match {
+        // This is a multi-platform project and `tlBspCrossProjectPlatforms` is set by a user explicitly.
+        case (Some(axes), Some(bspPlatforms)) =>
+          axes.exists {
+            case projectPlatform: PlatformAxis => bspPlatforms.contains(projectPlatform)
+            case _ => false
+          }
         case _ => oldValue
       }
     }

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativePlugin.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/GenerativePlugin.scala
@@ -558,11 +558,15 @@ ${indent(rendered.mkString("\n"), 1)}"""
 
     val renderedFailFast = job.matrixFailFast.fold("")("\n  fail-fast: " + _)
 
+    // TODO: Zainab - The simplest approach for project matrix support is to replace "2.12" with "2_12" in the scala matrix.
+    // We may want to keep "2.12" as-is and replace the dot in the build-specific step.
+    val scalas = job.scalas.map(_.replaceAll("\\.", "_"))
+
     // format: off
     val body = s"""name: ${wrap(job.name)}${renderedNeeds}${renderedCond}
 strategy:${renderedFailFast}
   matrix:
-${buildMatrix(2, "os" -> job.oses, "scala" -> job.scalas, "java" -> job.javas.map(_.render))}${renderedMatrices}
+${buildMatrix(2, "os" -> job.oses, "scala" -> scalas, "java" -> job.javas.map(_.render))}${renderedMatrices}
 runs-on: ${runsOn}${renderedEnvironment}${renderedContainer}${renderedPerm}${renderedEnv}${renderedConcurrency}${renderedOutputs}${renderedTimeoutMinutes}
 steps:
 ${indent(job.steps.map(compileStep(_, sbt, job.sbtStepPreamble, declareShell = declareShell)).mkString("\n\n"), 1)}"""
@@ -670,7 +674,7 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}
     githubWorkflowBuildTimeoutMinutes := Some(60),
     githubWorkflowBuildPreamble := Seq(),
     githubWorkflowBuildPostamble := Seq(),
-    githubWorkflowBuildSbtStepPreamble := Seq(s"++ $${{ matrix.scala }}"),
+    githubWorkflowBuildSbtStepPreamble := Nil,
     githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("test"), name = Some("Build project"))),
     githubWorkflowPublishPreamble := Seq(),
     githubWorkflowPublishPostamble := Seq(),
@@ -792,7 +796,7 @@ ${indent(jobs.map(compileJob(_, sbt)).mkString("\n\n"), 1)}
           Nil,
           exclusions
         ).map {
-          case _ :: scala :: _ :: tail => scala :: tail
+          case _ :: scala :: _ :: tail => scala.replaceAll("\\.", "_") :: tail
           case _ => sys.error("Bug generating artifact download steps") // shouldn't happen
         }
 

--- a/github-actions/src/main/scala/org/typelevel/sbt/gha/WorkflowJob.scala
+++ b/github-actions/src/main/scala/org/typelevel/sbt/gha/WorkflowJob.scala
@@ -72,7 +72,7 @@ object WorkflowJob {
       id: String,
       name: String,
       steps: List[WorkflowStep],
-      sbtStepPreamble: List[String] = List(s"++ $${{ matrix.scala }}"),
+      sbtStepPreamble: List[String] = Nil,
       cond: Option[String] = None,
       permissions: Option[Permissions] = None,
       env: Map[String, String] = Map(),

--- a/mergify/src/main/scala/org/typelevel/sbt/mergify/MergifyPlugin.scala
+++ b/mergify/src/main/scala/org/typelevel/sbt/mergify/MergifyPlugin.scala
@@ -18,7 +18,7 @@ package org.typelevel.sbt.mergify
 
 import org.typelevel.sbt.gha._
 import sbt._
-import sbtcrossproject.CrossPlugin.autoImport._
+import sbtprojectmatrix.ProjectMatrixKeys.projectMatrixBaseDirectory
 
 import java.nio.file.Path
 
@@ -153,7 +153,7 @@ object MergifyPlugin extends AutoPlugin {
   }
 
   private lazy val projectLabel = Def.setting {
-    val path = crossProjectBaseDirectory.?.value.getOrElse(baseDirectory.value).toPath
+    val path = projectMatrixBaseDirectory.?.value.getOrElse(baseDirectory.value).toPath
     val label = path.getFileName.toString
 
     def isRoot = path == (LocalRootProject / baseDirectory).value.toPath

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -28,3 +28,4 @@ Compile / unmanagedResourceDirectories ++= modules.map { module =>
 libraryDependencies ++= Seq(
   "io.get-coursier" %% "coursier" % "2.1.24"
 )
+addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.11.0")

--- a/settings/build.sbt
+++ b/settings/build.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("com.github.sbt" % "sbt-git" % "2.1.0")
-addSbtPlugin("org.portable-scala" % "sbt-crossproject" % "1.3.2")
+addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.11.0")

--- a/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
+++ b/settings/src/main/scala/org/typelevel/sbt/TypelevelSettingsPlugin.scala
@@ -19,7 +19,7 @@ package org.typelevel.sbt
 import com.github.sbt.git.GitPlugin
 import org.typelevel.sbt.kernel.V
 import sbt._
-import sbtcrossproject.CrossPlugin.autoImport._
+import sbtprojectmatrix.ProjectMatrixKeys.projectMatrixBaseDirectory
 
 import java.io.File
 import java.lang.management.ManagementFactory
@@ -49,7 +49,8 @@ object TypelevelSettingsPlugin extends AutoPlugin {
     Def.derive(scalaVersion := crossScalaVersions.value.last, default = true)
   )
 
-  private def onlyScala3 = Def.setting(crossScalaVersions.value.forall(_.startsWith("3.")))
+  private def onlyScala3 =
+    Def.setting((ThisBuild / crossScalaVersions).value.forall(_.startsWith("3.")))
 
   override def projectSettings = Seq(
     pomIncludeRepository := { _ => false },
@@ -337,20 +338,14 @@ object TypelevelSettingsPlugin extends AutoPlugin {
         old.filterNot(_ == flag)
     },
     unmanagedSourceDirectories ++= {
+      val rootBaseDirectory = (LocalRootProject / baseDirectory).value
+      val baseDir = projectMatrixBaseDirectory
+        .?
+        .value
+        .map(matrixDir => rootBaseDirectory / matrixDir.toString)
+        .getOrElse(baseDirectory.value)
       def extraDirs(suffix: String) =
-        crossProjectCrossType.?.value match {
-          case Some(crossType) =>
-            crossType
-              .sharedSrcDir(baseDirectory.value, Defaults.nameForSrc(configuration.value.name))
-              .toList
-              .map(f => file(f.getPath + suffix))
-          case None =>
-            List(
-              baseDirectory.value / "src" /
-                Defaults.nameForSrc(configuration.value.name) / s"scala$suffix"
-            )
-        }
-
+        List(baseDir / "src" / Defaults.nameForSrc(configuration.value.name) / s"scala$suffix")
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, y)) if y <= 12 => extraDirs("-2.12-")
         case Some((2, y)) if y >= 13 => extraDirs("-2.13+")


### PR DESCRIPTION
This is a POC for replacing cross project with project matrix.

Exactly how it should be incorporated is up for discussion. For example, we could support different plugins for cross project and project matrix for SBT 1, or only support project matrix for SBT 2.0.

## Status
It compiles and publishes locally, and works for itself (the sbt-typelevel build) and [weaver](https://github.com/zainab-ali/weaver-test/tree/project-matrix). It needs to be tested on many other projects. Note that the GitHub actions pipeline can't be tested in other projects until a snapshot is published.

## API changes
Users will need to rewrite their builds to use projectMatrix. The actual API surface of sbt-typelevel is mostly the same. The main changes are:
 -`CrossRootProject` needs a list of scala versions to be passed to it.
 - The `CrossRootProject.aggregate` function must be passed `ProjectMatrix` composite projects. For non-matrix projects, the `aggregate` function needs to be given a specific scala version. This is because a project definition doesn't contain enough information to determine its scala version.
 - The `TypelevelBspPlugin` uses `PlatformAxis` instead of cross project's `Platform` type.
 - The `++ {{ matrix.scala }}` in generated workflows has been replaced with a scala version suffix.